### PR TITLE
[WIP] Add substr_ macro

### DIFF
--- a/sources/pre.c
+++ b/sources/pre.c
@@ -338,6 +338,82 @@ higherlevel:
 						PutPreVar(namebuf,(UBYTE *)buf,(UBYTE *)"?a",1);
 						goto dostream;
 					}
+					else if ( StrICmp(namebuf,(UBYTE *)"substr_") == 0 ) {
+						/*
+						 * `substr_(STRING,POS,LEN)' gives the substring of
+						 * STRING starting from POS (the first character is
+						 * at POS=1) and with the length of LEN.
+						 */
+						LONG len = i-(s-namebuf)-2;
+						/*
+						 * Find two "," from the end.
+						 */
+						UBYTE *ss1, *ss2;
+						ss2 = s+len-1;
+						while ( ss2 >= s && *ss2 != ',' ) ss2--;
+						ss1 = ss2-1;
+						while ( ss1 >= s && *ss1 != ',' ) ss1--;
+						if ( ss1 < s ) {
+							/*
+							 * Not found.
+							 */
+							goto substr_error;
+						}
+						else {
+							/*
+							 * Parse the last two parameters as numbers.
+							 */
+							LONG n1, n2;
+							len = ss1-s;
+							*ss1++ = 0;
+							*ss2++ = 0;
+							if ( *ss1 == 0 || *ss2 == 0 ) {
+								goto substr_error;
+							}
+							ParseSignedNumber(n1,ss1);
+							ParseSignedNumber(n2,ss2);
+							if ( *ss1 != 0 || *ss2 != 0 ) {
+								goto substr_error;
+							}
+							/*
+							 * Non-positive POS parameter.
+							 */
+							if ( n1 <= 0 ) {
+								n1 = len+n1+1;
+							}
+							/*
+							 * Negative LEN parameter.
+							 */
+							if ( n2 < 0 ) {
+								n2 = len+n2+1;
+							}
+							/*
+							 * Constraints on the parameters.
+							 */
+							if ( n1 < 1 ) {
+								n1 = 1;
+							}
+							else if ( n1 > len+1 ) {
+								n1 = len+1;
+							}
+							if ( n2 < 0 ) {
+								n2 = 0;
+							}
+							else if ( n2 > len-n1+1 ) {
+								n2 = len-n1+1;
+							}
+							/*
+							 * Take the substring.
+							 */
+							memmove(s,s+n1-1,n2);
+							s[n2] = 0;
+							PutPreVar(namebuf,s,(UBYTE *)"?a",1);
+							goto dostream;
+						}
+substr_error:
+						MesPrint("@Illegal use of arguments in substr_");
+						Terminate(-1);
+					}
 					while ( *s ) {
 						if ( *s == '\\' ) s++;
 						if ( *s == ',' ) { *s = 0; nargs++; }

--- a/sources/pre.c
+++ b/sources/pre.c
@@ -327,6 +327,17 @@ higherlevel:
 						PutPreVar(namebuf,s,(UBYTE *)"?a",1);
 						goto dostream;
 					}
+					else if ( StrICmp(namebuf,(UBYTE *)"strlen_") == 0 ) {
+						/*
+						 * `strlen_(STRING)' gives the number of characters in
+						 * STRING.
+						 */
+						char buf[41];  /* up to 128-bit */
+						LONG len = i-(s-namebuf)-2;
+						LongCopy(len,buf);
+						PutPreVar(namebuf,(UBYTE *)buf,(UBYTE *)"?a",1);
+						goto dostream;
+					}
 					while ( *s ) {
 						if ( *s == '\\' ) s++;
 						if ( *s == ',' ) { *s = 0; nargs++; }

--- a/sources/startup.c
+++ b/sources/startup.c
@@ -1085,6 +1085,7 @@ VOID StartVariables()
 	PutPreVar((UBYTE *)"tolower_",(UBYTE *)("0"),(UBYTE *)("?a"),0);
 	PutPreVar((UBYTE *)"toupper_",(UBYTE *)("0"),(UBYTE *)("?a"),0);
 	PutPreVar((UBYTE *)"strlen_",(UBYTE *)("0"),(UBYTE *)("?a"),0);
+	PutPreVar((UBYTE *)"substr_",(UBYTE *)("0"),(UBYTE *)("?a"),0);
 	{
 		char buf[41];  /* up to 128-bit */
 		LONG pid;

--- a/sources/startup.c
+++ b/sources/startup.c
@@ -1084,6 +1084,7 @@ VOID StartVariables()
 	PutPreVar((UBYTE *)"optimscheme_",(UBYTE *)("0"),0,0);
 	PutPreVar((UBYTE *)"tolower_",(UBYTE *)("0"),(UBYTE *)("?a"),0);
 	PutPreVar((UBYTE *)"toupper_",(UBYTE *)("0"),(UBYTE *)("?a"),0);
+	PutPreVar((UBYTE *)"strlen_",(UBYTE *)("0"),(UBYTE *)("?a"),0);
 	{
 		char buf[41];  /* up to 128-bit */
 		LONG pid;


### PR DESCRIPTION
Although this may be a "feature creep" and I'm not sure whether many people find it useful or not, I would like to make a "Work in Progress" pull request, hoping this may stimulate other discussions.

As far as I know, there is no way/trick to extract a part of a string in FORM. So I experimentally implemented `substr_(STRING,POS,LEN)` macro, which is more or less `substr` of Perl and PHP but the first character is at POS=1. (Note that it is not `substring_(STRING,FROM,TO)`). `POS` and `LEN` are somewhat extended to non-positive and negative integers, respectively. Especially, `LEN=-1` means the actual length of `STRING`.

An application is defining a procedure with optional parameters:
```
#procedure Proc1(x,?opts)
  #define expand "-1"
  #do opt={`?opts'}
    #ifdef `opt'
      #switch `opt'
        #case expand
          #redefine expand "0"
          #break
        #case noexpand
          #redefine expand "-1"
          #break
        #default
          #if "`substr_(`opt',1,7)'" == "expand="
            #redefine expand "`substr_(`opt',8,-1)'"
          #else
            #message Error: illegal option of Proc1: `opt'
            #terminate
          #endif
          #break
      #endswitch
    #endif
  #enddo

  #message x=`x'
  #message expand=`expand'
#endprocedure
```
which accepts `#call Proc1(x,expand=2)` as well as `#call Proc1(x)`, `#call Proc1(x,expand)` or `#call Proc1(x,noexpand)`.

This branch also contains an implementation of `strlen_(STRING)`, but it is not primitive in the sense that it can be implemented based on `substr_`:
```
#procedure StrLen(?str,dest)
  #redefine `dest' "0"
  #do loop=1,1
    #if "`substr_(`?str',1,``dest'')'" != "`?str'"
      #redefine `dest' "{``dest''+1}"
      #redefine loop "0"
    #endif
  #enddo
#endprocedure

#define n ""
#call StrLen(12345,n)
```

Other string operations like `strreplace_(STRING,OLD,NEW)` can also be implemented based on `substr_`.