### PR TITLE
Added support for folds in the same file

### DIFF
--- a/sources/pre.c
+++ b/sources/pre.c
@@ -2147,21 +2147,26 @@ int Include(UBYTE *s, int type)
 		while ( *s == ' ' || *s == '\t' ) s++;
 		name = s;
 	}
-	if ( *s == '"' ) {
-		while ( *s && *s != '"' ) {
-			if ( *s == '\\' ) s++;
-			s++;
-		}
-		t = s++;
-	}
-	else {
-		while ( *s && *s != ' ' && *s != '\t' ) {
-			if ( *s == '\\' ) s++;
-			s++;
-		}
-		t = s;
-	}
-	while ( *s == ' ' || *s == '\t' ) s++;
+
+    t = s;
+    if ( *name != '#' ) {
+      if ( *s == '"' ) {
+        while ( *s && *s != '"' ) {
+          if ( *s == '\\' ) s++;
+          s++;
+        }
+        t = s++;
+      }
+      else {
+        while ( *s && *s != ' ' && *s != '\t' ) {
+          if ( *s == '\\' ) s++;
+          s++;
+        }
+        t = s;
+      }
+      while ( *s == ' ' || *s == '\t' ) s++;
+    }
+
 	if ( *s == '#' ) {
 		*t = 0;
 		s++;
@@ -2196,6 +2201,9 @@ int Include(UBYTE *s, int type)
 /*
 	We have the name of the file in 'name' and the fold in 'fold' (or NULL)
 */
+        if ( *name == 0) {
+          name = AM.InputFileName;
+        }
 	if ( OpenStream(name,type,0,PRENOACTION) == 0 ) {
 		if ( fold ) { M_free(fold,"foldname"); fold = 0; }
 		return(-1);


### PR DESCRIPTION
Can be used as:
    #include # foldname

Here is a code example (to be placed in file `unnamedfold.frm`):

```
#-

#include unnamedfold.frm # f1

#include # f1

.end

*--#[ f1 :
        #message fold included
*--#] f1 :
```