### PR TITLE
Change behaviour of "On fewerstatistics 0"

### DIFF
--- a/doc/manual/statements.tex
+++ b/doc/manual/statements.tex
@@ -3813,7 +3813,7 @@ the compression becomes very slow and doesn't gain very much extra.}
 small buffer is full. The keyword can be followed by a positive integer in 
 which case one out of that many of these statistics will be printed. If no 
 number is given the default value of 10 is used. When the number that 
-follows is zero, this feature is turned off (same effect as the value one).}
+follows is zero, statistics are never printed when sorting the small buffer.}
 
 \leftvitem{3.5cm}{fewerstats\index{on!fewerstats}}
 \rightvitem{13cm}{Same as the above fewerstatistics.}

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -108,6 +108,7 @@ VOID WriteStats(POSITION *plspace, WORD par)
 		if ( Expressions == 0 ) return;
 
 		if ( par == 0 ) {
+			if ( AC.ShortStatsMax == 0 ) return;
 			AR.ShortSortCount++;
 			if ( AR.ShortSortCount < AC.ShortStatsMax ) return;
 		}


### PR DESCRIPTION
Never print statistics for small buffer sort, if ShortStatsMax is 0

Often I want statistics enabled, but only for the final sort (to see the number of terms in output).
For large calculations, one can get many thousands of lines for small-buffer sorts, even with fewerstats set as large as possible.