### PR TITLE
Allow setting ContinuationLines to 0, meaning infinity (fixes #392)

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -811,3 +811,27 @@ assert result("F") =~ expr("
        + f(10,x3,x1,x4)
 ")
 *--#] Issue187 : 
+*--#[ Issue392_ContinuationLines_1 :
+#: ContinuationLines 1
+* Setting ContinuationLines to 0 should remove continuation line limit.
+auto symbol x;
+local ex = (xabcdefg + xhijklmnop)^100;
+.sort
+format C;
+#write <out.c> "%e" ex
+.end
+assert succeeded?
+assert file("out.c") =~ /[_] [+]=  /
+*--#] Issue392_ContinuationLines_1 :
+*--#[ Issue392_ContinuationLines_0 :
+#: ContinuationLines 0
+* Setting ContinuationLines to 0 should remove continuation line limit.
+auto symbol x;
+local ex = (xabcdefg + xhijklmnop)^100;
+.sort
+format C;
+#write <out.c> "%e" ex
+.end
+assert succeeded?
+assert !(file("out.c") =~ /[_] [+]=  /)
+*--#] Issue392_ContinuationLines_0 :

--- a/doc/manual/setup.tex
+++ b/doc/manual/setup.tex
@@ -71,9 +71,11 @@ it should not go much beyond 1000 on a 32\index{32 bits} bit machine. On a
 64\index{64 bits} bit machine it can go considerably further.}
 
 \leftvitem{4.0cm}{ContinuationLines\index{setup!continuationlines}\index{continuationlines}}
-\rightvitem{12.6cm}{The number of continuation lines that the local Fortran 
-compiler will allow. This limits the number of continuation lines, when the 
-output option `Format Fortran' (see \ref{substaformat}) is selected.}
+\rightvitem{12.6cm}{The maximum number of continuation lines, after which
+expressions will be broken apart when printed. The value of 0 means that no
+limit is imposed. The precise format of continuation lines depend on the
+current format (see \ref{substaformat}) settings; \#write instruction also
+allows for additional control (see \ref{prewrite}).}
 
 \leftvitem{4.0cm}{Define\index{setup!define}\index{define}}
 \rightvitem{12.6cm}{The syntax is as in the \#define instruction in the 

--- a/sources/sch.c
+++ b/sources/sch.c
@@ -2133,7 +2133,7 @@ WORD WriteTerm(WORD *term, WORD *lbrac, WORD first, WORD prtf, WORD br)
 					b = AO.bracket + 1;
 					t = term + 1;
 					while ( n > 0 && ( *b++ == *t++ ) ) { n--; }
-					if ( n <= 0 && ( ( AO.InFbrack < AM.FortranCont )
+					if ( n <= 0 && ( ( AM.FortranCont <= 0 || AO.InFbrack < AM.FortranCont )
 					|| ( lowestlevel == 0 ) ) ) {
 /*
 						We continue inside a bracket.
@@ -2362,7 +2362,7 @@ WrtTmes:				t = term;
 		}
 	}
 	if ( !br ) AO.IsBracket = 0;
-	if ( ( AO.InFbrack >= AM.FortranCont ) && lowestlevel ) {
+	if ( ( AM.FortranCont > 0 && AO.InFbrack >= AM.FortranCont ) && lowestlevel ) {
 		if ( AC.OutputMode == CMODE ) TokenToLine((UBYTE *)";");
 		if ( ( AC.OutputMode == FORTRANMODE || AC.OutputMode == PFORTRANMODE )
 		 && !first ) {

--- a/sources/setfile.c
+++ b/sources/setfile.c
@@ -665,7 +665,6 @@ int AllocSetups()
 
 	sp = GetSetupPar((UBYTE *)"continuationlines");
 	AM.FortranCont = sp->value;
-	if ( AM.FortranCont <= 0 ) AM.FortranCont = 1;
 	sp = GetSetupPar((UBYTE *)"oldorder");
 	AM.OldOrderFlag = sp->value;
 	sp = GetSetupPar((UBYTE *)"resettimeonclear");


### PR DESCRIPTION
Allow disabling the continuation line limit by setting `ContinuationLines` to 0.

Also fix the documentation: the continuation line limit applies not only for Fortran, but for all formats.

This fixes issue #392.