### PR TITLE
Define pre-proc vars for FORMTMP and FORMTMPSORT.

### DIFF
--- a/doc/manual/prepro.tex
+++ b/doc/manual/prepro.tex
@@ -87,6 +87,8 @@ any longer.
                processes in a job use the same number. A recovered session from
                a checkpoint (\ref{checkpoints}) keeps using the PID of the
                crushed session.
+\item[FORMTMP\_] The path of the FORMTMP directory.
+\item[FORMTMPSORT\_] The path of the FORMTMPSORT directory.
 \item[STOPWATCH\_] Same as `TIMER\_'.
 \item[SYSTEMERROR\_] The return value of the last \#system\ref{presystem}
                command when invoked with the -e\index{SYSTEMERROR\_} option.

--- a/sources/startup.c
+++ b/sources/startup.c
@@ -655,6 +655,12 @@ VOID ReserveTempFiles(int par)
 		}
 	}
 /*
+	Make these paths available to the user as pre-processor variables:
+*/
+	PutPreVar((UBYTE *)"FORMTMP_", AM.TempDir, 0, 0);
+	PutPreVar((UBYTE *)"FORMTMPSORT_", AM.TempSortDir, 0, 0);
+
+/*
 	We have now in principle a path but we will use its first element only.
 	Later that should become more complicated. Then we will use a path and
 	when one device is full we can continue on the next one.


### PR DESCRIPTION
Sometimes these paths can be useful in a form script, for use with #system, for example.