### PR TITLE
just fixing a few typos in sources/

### DIFF
--- a/sources/findpat.c
+++ b/sources/findpat.c
@@ -3,7 +3,7 @@
  *  Pattern matching of symbols and dotproducts.
  *  There are various routines because of the options in the id-statements
  *	like once, only, multi and many.
- *	These are amoung the oldest routines in FORM and that can be noticed,
+ *	These are among the oldest routines in FORM and that can be noticed,
  *	because the interplay with the function matching is not complete.
  *	When we match functions and halfway we fail we can backtrack properly.
  *	With the symbols, the dotproducts and the vectors (in pattern.c) there
@@ -51,7 +51,7 @@
 
 	This routine searches for an exact match. This means in particular:
 	1:	x^#	must match exactly.
-	2:	x^n? must have a single value for n that cannot be addapted.
+	2:	x^n? must have a single value for n that cannot be adapted.
 
 	When setp != 0 it points to a collection of sets
 	A match can occur only if no object will be left that belongs

--- a/sources/float.c
+++ b/sources/float.c
@@ -121,7 +121,7 @@ void RatToFloat(mpf_t result, UWORD *formrat, int ratsize);
 
 	From mpfr.h
 
-	The formats here are different. This has, amoung others, to do with
+	The formats here are different. This has, among others, to do with
 	the rounding. The result is that we need different aux variables
 	when working with mpfr and we need a different conversion routine
 	to float. It also means that we need to treat the mzv_ etc functions

--- a/sources/grcc.cc
+++ b/sources/grcc.cc
@@ -55,8 +55,8 @@ using namespace Grcc;
 
 static OptDef optDef[] = {
  {"Step",       "Generate particle assigned graphs",               GRCC_AGraph, 0},
- {"Outgrf",     "Output to file (out.grf)",                               False, 0},
- {"Outgrp",     "Output to file (out.grp)",                               False, 0},
+ {"Outgrf",     "Output to file (out.grf)",                              False, 0},
+ {"Outgrp",     "Output to file (out.grp)",                              False, 0},
  {"1PI",        "Only 1PI graphs",                                       True , 0},
  {"NoSelfLoop", "Exclude graphs with loops consist of 1 edge",           True , 0},
  {"NoTadpole",  "Exclude graphs with tadpoles (2 edge connected)",       True , 0},

--- a/sources/grcc.cc
+++ b/sources/grcc.cc
@@ -55,8 +55,8 @@ using namespace Grcc;
 
 static OptDef optDef[] = {
  {"Step",       "Generate particle assigned graphs",               GRCC_AGraph, 0},
- {"Outgrf",     "Ouput to file (out.grf)",                               False, 0},
- {"Outgrp",     "Ouput to file (out.grp)",                               False, 0},
+ {"Outgrf",     "Output to file (out.grf)",                               False, 0},
+ {"Outgrp",     "Output to file (out.grp)",                               False, 0},
  {"1PI",        "Only 1PI graphs",                                       True , 0},
  {"NoSelfLoop", "Exclude graphs with loops consist of 1 edge",           True , 0},
  {"NoTadpole",  "Exclude graphs with tadpoles (2 edge connected)",       True , 0},
@@ -4241,7 +4241,7 @@ void MGraph::bisearchME(int nd, int pd, int ned, MCOpi *mopi, MCBlock *mblk, int
     //  Search biconnected component
     //    visit : pd --> nd --> td
     //    ned : the number of edges between pd and nd.
-    //  Ouput
+    //  Output
     //
     //                 |
     //                 x----+

--- a/sources/grcc.h
+++ b/sources/grcc.h
@@ -1167,17 +1167,17 @@ class Assign {
     // entry point of assignment
     Bool    assignAllVertices(void);
 
-    // select a source node for assignmnet
+    // select a source node for assignment
     Bool    selectVertex(void);
     Bool    selectVertexSimp(int lastv);
 
-    // select a source leg of the node for assignmnet
+    // select a source leg of the node for assignment
     Bool    selectLeg(int v, int lastlg);
 
     // assign a vertex a interaction
     Bool    assignVertex(int v);
 
-    // assignment procedure is finishited.  Needs check.
+    // assignment procedure is finished.  Needs check.
     Bool    allAssigned(void);
 
     //===========================================
@@ -1192,7 +1192,7 @@ class Assign {
     // connect nodes and edges.
     void    connect(int n0, int l0, int eg, int el, int n1, int l1);
 
-    // Ouput to egraph
+    // Output to egraph
     Bool    fillEGraph(int aid, BigInt nsym, BigInt esym, BigInt nsym1);
 
     // reorder legs in accordance with the interaction definition

--- a/sources/minos.h
+++ b/sources/minos.h
@@ -51,7 +51,8 @@
 	The following typedef has been moved to form3.h where all the sizes
 	are defined for the various memory models.
 	We want MLONG to have a more or less fixed size.
-	In form3.h we try to fix it at 8 bytes. This should make files exchangable
+	In form3.h we try to fix it at 8 bytes.
+	This should make files exchangeable
 	between various 32-bits and 64-bits systems. At 4 bytes it might have
 	problems with files of more than 2 Gbytes.
 

--- a/sources/pattern.c
+++ b/sources/pattern.c
@@ -53,7 +53,7 @@
 			to many.
 		2:	Each symbol can have only one (wildcard) power, so
 			x^2*x^n? is illegal.
-		3:	when a single vector is used it replaces all occurences
+		3:	when a single vector is used it replaces all occurrences
 			of the vector. Therefore q*q(mu) or q*q(mu) cannot occur.
 			Also q*q cannot be done.
 		4:	Loose vector elements are replaced with p(mu), dotproducts

--- a/sources/poly.cc
+++ b/sources/poly.cc
@@ -1290,7 +1290,7 @@ void poly::divmod_one_term (const poly &a, const poly &b, poly &q, poly &r, bool
 		WORD nq,nr;
 	 
 		if (div) {
-			// if variables are divisable, divide coefficient
+			// if variables are divisible, divide coefficient
 			if (q.modp==0) {				
 				DivLong((UWORD *)&a[ai+1+AN.poly_num_vars], a[ai+a[ai]-1],
 								(UWORD *)&b[2+AN.poly_num_vars], b[b[1]],
@@ -1759,7 +1759,7 @@ void poly::divmod_heap (const poly &a, const poly &b, poly &q, poly &r, bool onl
 			ri += t[3];
 		}
 		else {
-			// divisable, so divide coefficient as well
+			// divisible, so divide coefficient as well
 			WORD nq, nr;
 	
 			if (q.modp==0) {

--- a/sources/startup.c
+++ b/sources/startup.c
@@ -792,7 +792,7 @@ classic:;
 	*t = 0;
 
 /*
-	Now we should asign a name to the main sort file and the two stage 4 files.
+	Now we should assign a name to the main sort file and the two stage 4 files.
 */
 	AM.S0->file.name = (char *)Malloc1(sizeof(char)*(i+14),"name for temporary files");
 	s = (UBYTE *)AM.S0->file.name;

--- a/sources/tables.c
+++ b/sources/tables.c
@@ -589,8 +589,8 @@ WORD DoTableExpansion(WORD *term, WORD level)
 	id tbl_(f?,?a) = f(?a);
 	When a tbl_ is used, automatically the corresponding element is compiled
 	at the start of the next module.
-	if TB,On,substitue [tablename], use of table RHS (if loaded)
-	if TB,Off,substitue [tablename], use of tbl_(table,...);
+	if TB,On,substitute [tablename], use of table RHS (if loaded)
+	if TB,Off,substitute [tablename], use of tbl_(table,...);
 
 
 	Still needed: Something like OverLoad to allow loading parts of a table
@@ -2136,7 +2136,7 @@ int ApplyExec(WORD *term, int maxtogo, WORD level)
 		}
 /*
 		If there are more arguments we have to do some
-		pattern matching. This should be easy. We addapted the
+		pattern matching. This should be easy. We adapted the
 		pattern, so that the array indices match already.
 */
 #ifdef WITHPTHREADS

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -52,7 +52,7 @@
 /*
   	#[ Variables :
 
-	The sortbot additions are from 17-may-2007 and after. They consitute
+	The sortbot additions are from 17-may-2007 and after. They constitute
 	an attempt to make the final merge sorting faster for the master.
 	This way the master has only one compare per term.
 	It does add some complexity, but the final merge routine (MasterMerge)
@@ -2530,7 +2530,7 @@ int InParallelProcessor(VOID)
  *	statement. These are usually the large expressions. It will divide
  *	the terms of these expressions over the workers, using a bucket system
  *	to reduce overhead (buckets are collections of a number of terms that
- *	are transfered together).
+ *	are transferred together).
  *	At the end of the expression when all terms have been assigned and 
  *	workers become available again, there is a load balancing system to
  *	take terms from the buckets of workers that still have to do many terms

--- a/sources/tools.c
+++ b/sources/tools.c
@@ -848,7 +848,7 @@ VOID PositionStream(STREAM *stream, LONG position)
  		#[ ReverseStatements :
 
 		Reverses the order of the statements in the buffer.
-		We allocate an extra buffer and copy a bit to and fro.
+		We allocate an extra buffer and copy a bit to and from.
 		Note that there are some nasties that cannot be resolved.
 */
 


### PR DESCRIPTION
found using

`codespell -L=nd,te,nin,ba,sav,pres,numer,dum,childs sources/`