### PR TITLE
Add brackets around dot products for format mathematica

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2297,3 +2297,47 @@ assert result("F3") =~ expr("+D")
 .end
 assert succeeded?
 *--#] Issue434 :
+*--#[ Issue460_1 :
+* Improve format mathematica, for powers of dot products
+Vector p,q;
+Local test = p.q + p.q^2 + 1/p.q + 1/p.q^2;
+Format Mathematica;
+Print;
+.end
+assert succeeded?
+assert result("test") =~ expr("(p.q)^(-2) + (p.q)^(-1) + (p.q) + (p.q)^2")
+*--#] Issue460_1 :
+*--#[ Issue460_2 :
+* Improve format mathematica, for powers of dot products
+* Check regular mode is unchanged:
+Vector p,q;
+Local test = p.q + p.q^2 + 1/p.q + 1/p.q^2;
+Print;
+.end
+assert succeeded?
+assert result("test") =~ expr("p.q^-2 + p.q^-1 + p.q + p.q^2")
+*--#] Issue460_2 :
+*--#[ Issue460_3 :
+* Improve format mathematica, for powers of dot products
+* Also check C mode:
+Vector p,q;
+Local test = p.q + p.q^2 + 1/p.q + 1/p.q^2;
+Format C;
+Print;
+.end
+assert succeeded?
+assert result("test") =~ expr("pow(p_q,-2) + pow(p_q,-1) + p_q + pow(p_q,2)")
+*--#] Issue460_3 :
+*--#[ Issue460_4 :
+* Improve format mathematica, for powers of dot products
+* Also check Fortran mode:
+Vector p,q;
+Local test = p.q + p.q^2 + 1/p.q + 1/p.q^2;
+Format Fortran;
+Print;
+.end
+assert succeeded?
+assert stdout =~ exact_pattern(<<'EOF')
+& p_q**(-2) + p_q**(-1) + p_q + p_q**2
+EOF
+*--#] Issue460_4 :

--- a/sources/sch.c
+++ b/sources/sch.c
@@ -1770,6 +1770,8 @@ WORD WriteSubTerm(WORD *sterm, WORD first)
 				if ( !first ) MultiplyToLine();
 				if ( AC.OutputMode == CMODE && t[2] != 1 )
 					TokenToLine((UBYTE *)"pow(");
+				if ( AC.OutputMode == MATHEMATICAMODE )
+					TokenToLine((UBYTE *)"(");
 				Out = StrCopy(FindVector(*t),buffer);
 /*				Out = StrCopy(VARNAME(vectors,*t - AM.OffsetVector),buffer); */
 				t++;
@@ -1779,6 +1781,10 @@ WORD WriteSubTerm(WORD *sterm, WORD first)
 				else *Out++ = '.';
 				Out = StrCopy(FindVector(*t),Out);
 /*				Out = StrCopy(VARNAME(vectors,*t - AM.OffsetVector),Out); */
+				if ( AC.OutputMode == MATHEMATICAMODE ) {
+					*Out++ = ')';
+					*Out = 0;
+				}
 				t++;
 				if ( *t != 1 ) WrtPower(Out,*t);
 				t++;


### PR DESCRIPTION
Mathematica does not interpret "a.b^2" as intended, add brackets around dot products when printing with `Format mathematica;` regardless of the presence of a power.

Fixes #460 