### PR TITLE
Fix the FORM5 optimization regression

### DIFF
--- a/sources/optimize.cc
+++ b/sources/optimize.cc
@@ -4348,16 +4348,12 @@ VOID generate_output (const vector<WORD> &instr, int exprnr, int extraoffset, co
 			WORD *now = start;
 			int b=0;
 			for (const WORD *t=AT.WorkPointer; *t!=0; t+=*t) {
- 				if (brackets[b].size() != 0) {
- 					memcpy(now, &brackets[b][0], brackets[b].size()*sizeof(WORD));
- 					now += brackets[b].size();
- 				}
-/*
 				if ( ( brackets[b].size() != 0 ) && ( brackets[b][0] == 0 ) ) break;
 				*now++ = *t + brackets[b].size();
-*/
-				memcpy(now, &brackets[b][0], brackets[b].size()*sizeof(WORD));
-				now += brackets[b].size();
+				if (brackets[b].size() != 0) {
+					memcpy(now, &brackets[b][0], brackets[b].size()*sizeof(WORD));
+					now += brackets[b].size();
+				}
 				memcpy(now, t+1, (*t-1)*sizeof(WORD));
 				now += *t-1;
 				b++;


### PR DESCRIPTION
As written in https://github.com/vermaseren/form/issues/7#issuecomment-1677266031, this reverts a part of 1d4b775, and somehow fixes the optimization regression.

Actually, I understand neither why it fixes the regression nor what was the intention of [the change](https://github.com/vermaseren/form/commit/1d4b775308c457c9a8ca72aa64890ac9642ec4dd?w=1#diff-b041575ff5a324d5d3b06ee7e9d3ac313fab602aad39112ca26348a28ce039baL4330-R4359).
