### PR TITLE
check.rb: terminating timed-out processes properly

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,7 @@ like the GNU glibc.
 The threaded version of FORM needs a Posix compliant implementation of threads
 (pthreads). The parallel version ParFORM needs an MPI implementation.
 
-The automated test suite of FORM requires Ruby version >= 1.8 and the testing
+The automated test suite of FORM requires Ruby version >= 1.9 and the testing
 framework "test/unit". For the latter, you may need to install test-unit gem
 separately.
 
@@ -174,7 +174,7 @@ can be used.
 Testing
 =======
 
-If Ruby version >= 1.8 and "test/unit" are installed on your system, the
+If Ruby version >= 1.9 and "test/unit" are installed on your system, the
 configure script enables the automated test suite. Then you can run it by
 
     make check

--- a/check/README.md
+++ b/check/README.md
@@ -9,7 +9,7 @@ Prerequisites
 -------------
 
 The test runner script is written in [Ruby](https://www.ruby-lang.org/)
-and requires Ruby 1.8 or later. The script uses the so-called `test/unit`
+and requires Ruby 1.9 or later. The script uses the so-called `test/unit`
 library. In some Linux distributions the library is installed together with
 Ruby, while some distributions may have the library as an optional package,
 or one may need to manually install

--- a/configure.ac
+++ b/configure.ac
@@ -997,13 +997,13 @@ AM_CONDITIONAL(CONFIG_MAKEINDEX, [test "x$MAKEINDEX" != x])
 AM_CONDITIONAL(CONFIG_HTLATEX, [test "x$HTLATEX" != x])
 AM_CONDITIONAL(CONFIG_LATEX2HTML, [test "x$LATEX2HTML" != x])
 
-# Check for Ruby >= 1.8 and test/unit.
+# Check for Ruby >= 1.9 and test/unit.
 AC_PATH_PROG(RUBY, ruby, "")
 ok=yes
 test "x$RUBY" = x && ok=no
 if test "x$ok" = xyes; then
-	AC_MSG_CHECKING([whether ruby >= 1.8])
-	$RUBY -e 'exit(1) if RUBY_VERSION < "1.8.0"' >/dev/null 2>&1 || ok=no
+	AC_MSG_CHECKING([whether ruby >= 1.9])
+	$RUBY -e 'exit(1) if RUBY_VERSION < "1.9.0"' >/dev/null 2>&1 || ok=no
 	AC_MSG_RESULT([$ok])
 fi
 if test "x$ok" = xyes; then


### PR DESCRIPTION
This patch makes `check.rb` properly kill test processes that have timed out.

@jodavies Could you give it a try?