### PR TITLE
Fix polyratfun bugs caused by incorrect clean flag

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2173,6 +2173,122 @@ print +s;
 assert succeeded?
 assert result("A") =~ expr("+N1")
 *--#] Issue325 :
+*--#[ Issue336_1 :
+#-
+CFunction rat,f,tag;
+Symbol a,b,y,x;
+
+* Build lots of combinations
+Local test = (
+	+ f(1)
+	+ f(1+x)
+	+ f(1+x+x^2)
+	+ f(x+x^2)
+	+ f(1+x^-1)
+	+ f(1+x^-2)
+	+ f(1+x+x^-1)
+	+ f(x+x^-1)
+	+ f(x^-1)
+	+ f(x^-2)
+	+ f(x^-1+x^-2)
+	+ f(1+x+y)
+	+ f(1+x+x^2+y+y^2)
+	+ f(x+x^2+y+y^2)
+	+ f(1+x^-1+y^-1)
+	+ f(1+x^-2+y^-2)
+	+ f(1+x+x^-1+y+y^-1)
+	+ f(x+x^-1+y+y^-1)
+	+ f(x^-1+y^-1)
+	+ f(x^-2+y^-2)
+	+ f(x^-1+x^-2+y^-1+y^-2)
+	+ f(x^-1*x^-1)
+	+ f(x^-2+x^-1*y^-1+y^-2)
+	+ f(x^2+x^1*y^-1+y^-2)
+	)^2;
+DropCoefficient;
+* Create rational polys, with both orderings of the num and den
+Identify f(a?)*f(b?) = rat(a,b) + rat(a,b);
+.sort
+DropCoefficient;
+#$i = 0;
+Multiply tag($i);
+$i = $i+1;
+Print +s;
+.sort
+
+* Everything should cancel in the end, and we should get zero.
+Identify rat(?a) = rat(?a) - x*rat(?a);
+Bracket x;
+.sort
+
+PolyRatFun rat;
+Collect f;
+.sort
+Identify x = 1;
+Identify f(x?) = x;
+
+Print;
+.end
+assert succeeded?
+assert result("test") =~ expr("0")
+*--#] Issue336_1 :
+*--#[ Issue336_2 :
+#-
+CFunction rat,f,tag;
+Symbol a,b,y,x;
+
+* Build lots of combinations
+Local test = (
+	+ f(1)
+	+ f(1+x)
+	+ f(1+x+x^2)
+	+ f(x+x^2)
+	+ f(1+x^-1)
+	+ f(1+x^-2)
+	+ f(1+x+x^-1)
+	+ f(x+x^-1)
+	+ f(x^-1)
+	+ f(x^-2)
+	+ f(x^-1+x^-2)
+	+ f(1+x+y)
+	+ f(1+x+x^2+y+y^2)
+	+ f(x+x^2+y+y^2)
+	+ f(1+x^-1+y^-1)
+	+ f(1+x^-2+y^-2)
+	+ f(1+x+x^-1+y+y^-1)
+	+ f(x+x^-1+y+y^-1)
+	+ f(x^-1+y^-1)
+	+ f(x^-2+y^-2)
+	+ f(x^-1+x^-2+y^-1+y^-2)
+	+ f(x^-1*x^-1)
+	+ f(x^-2+x^-1*y^-1+y^-2)
+	+ f(x^2+x^1*y^-1+y^-2)
+	)^2;
+DropCoefficient;
+* Create rational polys, with both orderings of the num and den
+Identify f(a?)*f(b?) = rat(a,b) + rat(a,b);
+.sort
+DropCoefficient;
+#$i = 0;
+Multiply tag($i);
+$i = $i+1;
+Print +s;
+.sort
+
+* Everything should cancel in the end, and we should get zero.
+Identify rat(?a) = rat(?a) - f(rat(?a));
+.sort
+
+PolyRatFun rat;
+.sort
+
+Identify f(x?) = x;
+
+Print;
+.end
+assert succeeded?
+assert result("test") =~ expr("0")
+*--#] Issue336_2 :
 *--#[ Issue340 :
 * Calling "argtoextrasymbol" of a function containing "g5_" crashes
 CF f, g;

--- a/sources/poly.cc
+++ b/sources/poly.cc
@@ -2560,12 +2560,24 @@ const poly poly::argument_to_poly (PHEAD WORD *e, bool with_arghead, bool sort_u
 	}
 
 	res[0] = ri;
-	
-	// normalize, since the Form order is probably not the polynomial order
-	// for multiple variables
 
-	if (sort_univar || AN.poly_num_vars>1)
+	// JD: For univariate cases, check whether the ordering is correct or not.
+	// There are various ways to arrive here, but with an incorrect ordering, such
+	// as interactions with collect, moving a polyratfun out of another function
+	// argument, etc.
+	// If the ordering is not correct, make sure we normalize. In multivariate cases,
+	// always normalize as before.
+	if (sort_univar == false && AN.poly_num_vars == 1) {
+		if (res.number_of_terms() >= 2) {
+			if(res[2] < res.last_monomial()[2]) {
+				sort_univar = true;
+			}
+		}
+	}
+
+	if (sort_univar || AN.poly_num_vars>1) {
 		res.normalize();
+	}
 
 	NumberFree(den,"poly::argument_to_poly");
 	NumberFree(pro,"poly::argument_to_poly");


### PR DESCRIPTION
There are some known issues regarding polyratfun which are not easy to fix.

The least we can do is to crash when we hit something that is definitely wrong, for now.

This "fixes" the example in Issue #336 

This does not catch Issue #270 !