### PR TITLE
Don't run moebius_3 test when available memory is limited

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -170,6 +170,10 @@ assert result("F") =~ expr("
 P;
 .end
 #time_dilation 4.0
+# memory usage is so intense
+#pend_if serial? && total_memory < 8_000_000_000
+#pend_if threaded? && total_memory < 20_000_000_000
+#pend_if mpi? && total_memory < 20_000_000_000
 # too heavy on GitHub (often fails)
 #pend_if github? && valgrind?
 assert succeeded?


### PR DESCRIPTION
Here, I simply set constant memory requirements. (Maybe this is enough?) In principle, one can consider the number of cpus etc. but it may be too complicated.

The serial version requires 8 GB (in SI, not GiB), so 8 GiB system memory is enough to run it. The threaded/mpi versions need 20GB. Note that [16 GiB is available on GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).