### PR TITLE
Fix printing empty set with on codes

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2383,3 +2383,15 @@ assert stdout =~ exact_pattern(<<'EOF')
 & p_q**(-2) + p_q**(-1) + p_q + p_q**2
 EOF
 *--#] Issue460_4 :
+*--#[ Issue486 :
+On codes;
+Symbol x,y;
+Set empty;
+Set nonempty: x,y;
+.end
+assert succeeded?
+assert stdout =~ exact_pattern(<<'EOF')
+   empty(13):
+   nonempty(14): x y
+EOF
+*--#] Issue486 :

--- a/sources/sch.c
+++ b/sources/sch.c
@@ -1042,7 +1042,7 @@ VOID WriteLists(VOID)
 				element = Sets[i].first;
 				LastElement = Sets[i].last;
 				type = Sets[i].type;
-				do {
+				while ( element < LastElement ) {
 					TokenToLine((UBYTE *)" ");
 					number = SetElements[element++];
 					switch ( type ) {
@@ -1110,7 +1110,7 @@ VOID WriteLists(VOID)
 							TokenToLine(OutScr);
 							break;
 					}
-				} while ( element < LastElement );
+				}
 			}
 		}
 		*skip = 0;


### PR DESCRIPTION
Avoid accessing array out of bounds when a set is empty.

Closes #486 