### PR TITLE
Fix RemoveSpectator after making holes in array

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -1924,6 +1924,42 @@ Symbol x;
 .end
 assert succeeded?
 *--#] Issue222 : 
+*--#[ Issue231 :
+Symbol x,y,z;
+Local F = x + y + x*z;
+.sort
+#do i=1,9
+	CreateSpectator S`i',"S`i'.spec";
+#enddo
+If (Count(y,1) > 0) ToSpectator S1;
+.sort
+* Remove some spectators, making holes
+#do i=1,9,2
+	RemoveSpectator S`i';
+#enddo
+* Add to a spectator after making "holes"
+If (Count(z,1) > 0) ToSpectator S4;
+.sort
+* Retrieve:
+CopySpectator G = S4;
+.sort
+* Empty
+RemoveSpectator S4;
+Print;
+.sort
+On Codes;
+* New spectator, should fill in the first "hole"
+CreateSpectator S1 "S1.spec";
+.end
+assert succeeded?
+assert result("F") =~ expr("x")
+assert result("G") =~ expr("x*z")
+assert stdout =~ exact_pattern(<<'EOF')
+ Expressions
+   F(local)(0) S2(spectator)(1) S6(spectator)(2) S8(spectator)(3) G(local)(4) 
+   S1(spectator)(5)
+EOF
+*--#] Issue231 :
 *--#[ Issue253 :
 * Memory error for local $-variable in TFORM
 #$x = 0;

--- a/sources/spectator.c
+++ b/sources/spectator.c
@@ -252,7 +252,11 @@ int CoRemoveSpectator(UBYTE *inp)
 		return(1);
 	}
 	for ( i = 0; i < AM.SizeForSpectatorFiles; i++ ) {
-		if ( StrCmp((UBYTE *)(AM.SpectatorFiles[i].name),(UBYTE *)(inp)) == 0 ) break;
+		if ( AM.SpectatorFiles[i].name != 0 ) {
+			if ( StrCmp((UBYTE *)(AM.SpectatorFiles[i].name),(UBYTE *)(inp)) == 0 ) {
+				break;
+			}
+		}
 	}
 	if ( i >= AM.SizeForSpectatorFiles ) {
 		MesPrint("&Spectator %s not found.",inp);


### PR DESCRIPTION
Check that spectator names are not null pointers, before comparing.

RemoveSpectator leaves a hole in the SpectatorFiles array. One could fix this by moving all higher spectators to fill the hole, but creating new spectators later will at least fill the holes, currently.

Closes #231 