### PR TITLE
Format mathematica: enclose expressions in brackets

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -186,6 +186,57 @@ P;
 assert succeeded?
 assert result("F") =~ expr("1")
 *--#] Issue21 : 
+*--#[ Issue23 :
+#-
+CFunction f,g;
+Symbol x;
+
+Local F = (x+1)^2*(f(x)+g(x))^2;
+Local G = (x+1)^2*(f(x)+g(x))^2;
+
+Format Mathematica;
+
+Bracket x;
+Print +s F;
+.sort
+
+Print +s G;
+.end
+assert succeeded?
+assert stdout =~ exact_pattern(<<'EOF')
+   F = (
+
+       + x * (
+          + 2*f[x]^2
+          + 4*f[x]*g[x]
+          + 2*g[x]^2
+          )
+
+       + x^2 * (
+          + f[x]^2
+          + 2*f[x]*g[x]
+          + g[x]^2
+          )
+
+       + f[x]^2
+          + 2*f[x]*g[x]
+          + g[x]^2
+         );
+EOF
+assert stdout =~ exact_pattern(<<'EOF')
+   G = (
+       + f[x]^2
+       + 2*f[x]^2*x
+       + f[x]^2*x^2
+       + 2*f[x]*g[x]
+       + 4*f[x]*g[x]*x
+       + 2*f[x]*g[x]*x^2
+       + g[x]^2
+       + 2*g[x]^2*x
+       + g[x]^2*x^2
+      );
+EOF
+*--#] Issue23 :
 *--#[ Issue25 :
 * [tform] ZERO_ is always 1 when InParallel mode
 L F1 = 1;
@@ -2347,7 +2398,7 @@ Format Mathematica;
 Print;
 .end
 assert succeeded?
-assert result("test") =~ expr("(p.q)^(-2) + (p.q)^(-1) + (p.q) + (p.q)^2")
+assert result("test") =~ expr("((p.q)^(-2) + (p.q)^(-1) + (p.q) + (p.q)^2)")
 *--#] Issue460_1 :
 *--#[ Issue460_2 :
 * Improve format mathematica, for powers of dot products

--- a/sources/sch.c
+++ b/sources/sch.c
@@ -2639,6 +2639,9 @@ WORD WriteAll(VOID)
 				TokenToLine((UBYTE *)")");
 			}
 			TOKENTOLINE(" =","=");
+			if ( AC.OutputMode == MATHEMATICAMODE ) {
+				TOKENTOLINE(" (","(");
+			}
 			lbrac = 0;
 			AO.InFbrack = 0;
 			if ( AC.OutputMode == FORTRANMODE || AC.OutputMode == PFORTRANMODE )
@@ -2691,6 +2694,9 @@ WORD WriteAll(VOID)
 					TOKENTOLINE(" + 1 * ( ","+1*(")
 					PrtTerms();
 					TOKENTOLINE(" )",")")
+				}
+				if ( AC.OutputMode == MATHEMATICAMODE ) {
+					TokenToLine((UBYTE *)")");
 				}
 				if ( AC.OutputMode != FORTRANMODE && AC.OutputMode != PFORTRANMODE )
 					TokenToLine((UBYTE *)";");


### PR DESCRIPTION
If there are blank lines in the output (for eg when printing a bracketed expression) mathematica considers the expression to have finished. This is avoided by wrapping the entire expression in brackets.

Closes #23 