### PR TITLE
Move the LogType check inside WriteStats

### DIFF
--- a/sources/declare.h
+++ b/sources/declare.h
@@ -752,7 +752,7 @@ extern WORD   WriteExpression(WORD *,LONG);
 extern WORD   WriteInnerTerm(WORD *,WORD);
 extern VOID   WriteLists(VOID);
 extern VOID   WriteSetup(VOID);
-extern VOID   WriteStats(POSITION *,WORD);
+extern VOID   WriteStats(POSITION *,WORD,WORD);
 extern WORD   WriteSubTerm(WORD *,WORD);
 extern WORD   WriteTerm(WORD *,WORD *,WORD,WORD,WORD);
 extern WORD   execarg(PHEAD WORD *,WORD);

--- a/sources/ftypes.h
+++ b/sources/ftypes.h
@@ -323,6 +323,18 @@ typedef int (*TFUN1)();
 #define SORTPOWERFIRST 2
 #define SORTANTIPOWER 3
 
+/* These control the output of WriteStats. The different sort
+ * types have differently formatted stats. These variables should
+ * not have arbitrary values since they are also used as array
+ * indices by WriteStats. */
+#define STATSSPLITMERGE 0
+#define STATSMERGETOFILE 1
+#define STATSPOSTSORT 2
+/* CHECKLOGTYPE implies that statistics will not be printed in
+ * the log file if AM.LogType = 1 (when running with -ll or -F). */
+#define NOCHECKLOGTYPE 0
+#define CHECKLOGTYPE 1
+
 #define NMIN4SHIFT 4
 /*
 	The next are the main codes.

--- a/sources/parallel.c
+++ b/sources/parallel.c
@@ -1775,7 +1775,7 @@ int PF_Processor(EXPRESSIONS e, WORD i, WORD LastExpression)
 				genterms += PF_stats[k][3];
 			}
 			AT.SS->GenTerms = genterms;
-			WriteStats(&PF_exprsize, 2);
+			WriteStats(&PF_exprsize, STATSPOSTSORT, NOCHECKLOGTYPE);
 			Expressions[AR.CurExpr].size = PF_exprsize;
 		}
 		PF_Statistics(PF_stats,0);

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -4010,7 +4010,7 @@ EndOfMerge:
 	for ( j = 1; j <= numberofworkers; j++ ) {
 		S->GenTerms += AB[j]->T.SS->GenTerms;
 	}
-	WriteStats(&position,2);
+	WriteStats(&position,STATSPOSTSORT,NOCHECKLOGTYPE);
 	Expressions[AR0.CurExpr].counter = S->TermsLeft;
 	Expressions[AR0.CurExpr].size = position;
 /*
@@ -4152,7 +4152,7 @@ int SortBotMasterMerge(VOID)
 		S->GenTerms += AB[j]->T.SS->GenTerms;
 	}
 	S->TermsLeft = numberofterms;
-	WriteStats(&position,2);
+	WriteStats(&position,STATSPOSTSORT,NOCHECKLOGTYPE);
 	Expressions[AR.CurExpr].counter = S->TermsLeft;
 	Expressions[AR.CurExpr].size = position;
 	AS.MasterSort = 0;


### PR DESCRIPTION
This allows other code to be included in the lock, in particular to avoid race conditions when temporarity setting `AC.LogHandle = -1` when AM.LogType is 1.

Fixes #470