### PR TITLE
Print a warning when saving expr with too-long names

### DIFF
--- a/sources/store.c
+++ b/sources/store.c
@@ -366,6 +366,7 @@ int CoSave(UBYTE *inp)
 	UBYTE *p, c;
 	WORD n = 0, i;
 	WORD error = 0, type, number;
+	WORD exprInStorageFlag = 0;
 	LONG RetCode = 0, wSize;
 	EXPRESSIONS e;
 	INDEXENTRY *ind;
@@ -421,6 +422,9 @@ int CoSave(UBYTE *inp)
 			c = *p; *p = 0;
 			if ( GetVar(inp,&type,&number,CEXPRESSION,NOAUTO) != NAMENOTFOUND ) {
 				if ( e[number].status == STOREDEXPRESSION ) {
+					if ( StrLen(AC.exprnames->namebuffer+e[number].name) > MAXENAME ) {
+						MesPrint("&Warning: saved expression name over %d char: %s", MAXENAME, AC.exprnames->namebuffer+e[number].name);
+					}
 /*
 		Here we have to locate the stored expression, copy its index entry
 		possibly after making a new fileindex and then copy the whole
@@ -518,11 +522,15 @@ NextExpr:;
 			,(LONG)sizeof(struct FiLeInDeX)) != (LONG)sizeof(struct FiLeInDeX) ) goto SavWrt;
 	}
 	else if ( !AP.preError ) {				/* All stored expressions should be saved. Easy */
+		/* Make sure there is at least one stored expression: */
 		if ( n > 0 ) { do {
-			if ( e->status == STOREDEXPRESSION ) break;
+			if ( StrLen(AC.exprnames->namebuffer+e->name) > MAXENAME ) {
+				MesPrint("&Warning: saved expr name over %d char: %s", MAXENAME, AC.exprnames->namebuffer+e->name);
+			}
+			if ( e->status == STOREDEXPRESSION ) exprInStorageFlag = 1;
 			e++;
 		} while ( --n > 0 ); }
-		if ( n ) {
+		if ( exprInStorageFlag ) {
 			wSize = TOLONG(AT.WorkTop) - TOLONG(AT.WorkPointer);
 			PUTZERO(scrpos);
 			SeekFile(AR.StoreData.Handle,&scrpos,SEEK_SET);		/* Start at the beginning */


### PR DESCRIPTION
This addresses #192 and #334 .

Terminating on this condition will certainly break people's existing FORM scripts.

At least print a warning, since one can certainly produce bugs by using names over MAXENAME (16) characters.

An example bug:
```
#-
Off statistics;

Global abcdefghijklmnop = 16;
Global abcdefghijklmnopq = 17;
Global abcdefghijklmnopqr = 18;
Global abcdefghijklmnopqrs = 19;
Global abcdefghijklmnopqrst = 20;
Global abcdefghijklmnopqrstu = 21;

Print +s;
.store

*Save test.res, abcdefghijklmnop, abcdefghijklmnopq;
Save test.res;
.end
```
then
```
#-
Off Statistics;

Load test.res;

Local Abcdefghijklmnop      = abcdefghijklmnop;
Local Abcdefghijklmnopq     = abcdefghijklmnopq;
Local Abcdefghijklmnopqr    = abcdefghijklmnopqr;
Local Abcdefghijklmnopqrs   = abcdefghijklmnopqrs;
Local Abcdefghijklmnopqrst  = abcdefghijklmnopqrst;
*Local Abcdefghijklmnopqrstu = abcdefghijklmnopqrstu;

Print +s;
.end
```
which gives:
```
FORM 4.1 (Apr 26 2024, v4.1-20131025-620-ga113449-dirty)  Run: Fri Apr 26 15:09:02 2024
    #-
 abcdefghijklmnop loaded
 abcdefghijklmnopq loaded
 abcdefghijklmnopqr loaded
 abcdefghijklmnopqrs loaded
 abcdefghijklmnopqrstx loaded
 abcdefghijklmnopqrst loaded

   Abcdefghijklmnop =
       + 16
      ;

   Abcdefghijklmnopq =
       + 17
      ;

   Abcdefghijklmnopqr =
       + 18
      ;

   Abcdefghijklmnopqrs =
       + 19
      ;

   Abcdefghijklmnopqrst =
       + 21
      ;

  0.00 sec out of 0.00 sec
```
Here, `abcdefghijklmnopqrst` is loaded with the incorrect name `abcdefghijklmnopqrstx`, and `abcdefghijklmnopqrstu` is loaded as `abcdefghijklmnopqrst`. Then `Abcdefghijklmnopqrst` has value `21` and not `20`.

With the patch, upon saving, you get:
```
test.frm Line 15 --> Warning: saved expression name over 16 char: abcdefghijklm
nopq
test.frm Line 15 --> Warning: saved expression name over 16 char: abcdefghijklm
nopqr
test.frm Line 15 --> Warning: saved expression name over 16 char: abcdefghijklm
nopqrs
test.frm Line 15 --> Warning: saved expression name over 16 char: abcdefghijklm
nopqrst
test.frm Line 15 --> Warning: saved expression name over 16 char: abcdefghijklm
nopqrstu
```

What do you think? I used MesPrint and not Warning/HighWarning since those don't take arguments for the format string.
