### PR TITLE
test(check.rb): add optional expected_message for error/warning checks

### DIFF
--- a/check/check.rb
+++ b/check/check.rb
@@ -618,30 +618,49 @@ module FormTest
   end
 
   # true if the FORM job put warning messages.
-  def warning?
-    @stdout =~ /(^|\R)\S+ Line \d+ --> Warning/
+  def warning?(expected_message = nil)
+    if expected_message.nil?
+      @stdout =~ /(^|\R)\S+ Line \d+ --> Warning/
+    else
+      @stdout =~ Regexp.new("(^|\\R)\\S+ Line \\d+ --> Warning: .*#{Regexp.escape(expected_message)}")
+    end
   end
 
   # true if the FORM job put preprocessor errors.
-  def preprocess_error?
-    @stdout =~ /(^|\R)\S+ Line \d+ ==>/
+  def preprocess_error?(expected_message = nil)
+    if expected_message.nil?
+      @stdout =~ /(^|\R)\S+ Line \d+ ==>/
+    else
+      @stdout =~ Regexp.new("(^|\\R)\\S+ Line \\d+ ==> .*#{Regexp.escape(expected_message)}")
+    end
   end
 
   # true if the FORM job put compile-time errors.
-  def compile_error?
-    @stdout =~ /(^|\R)\S+ Line \d+ -->/
+  def compile_error?(expected_message = nil)
+    if expected_message.nil?
+      @stdout =~ /(^|\R)\S+ Line \d+ -->/
+    else
+      @stdout =~ Regexp.new("(^|\\R)\\S+ Line \\d+ --> .*#{Regexp.escape(expected_message)}")
+    end
   end
 
   # true if the FORM job put run-time errors.
   # NOTE: indeed this implementation detects abnormal terminations
   # via "Terminate()", which also happens for preprocessor/compiler errors.
-  def runtime_error?
+  def runtime_error?(expected_message = nil)
     if serial?
-      @stdout =~ /Program terminating at \S+ Line \d+ -->/
+      result = @stdout =~ /Program terminating at \S+ Line \d+ -->/
     elsif threaded?
-      @stdout =~ /Program terminating in thread \d+ at \S+ Line \d+ -->/
+      result = @stdout =~ /Program terminating in thread \d+ at \S+ Line \d+ -->/
     elsif mpi?
-      @stdout =~ /Program terminating in process \d+ at \S+ Line \d+ -->/
+      result = @stdout =~ /Program terminating in process \d+ at \S+ Line \d+ -->/
+    end
+    if expected_message.nil?
+      result
+    else
+      # NOTE: it just tests if the output contains the expected message,
+      # which is probably put before "Terminate()" is called.
+      result && @stdout =~ Regexp.new(Regexp.escape(expected_message))
     end
   end
 


### PR DESCRIPTION
This may be good for writing test cases that give errors/warnings.

Example:
```form
*--#[ example :
Table t(1:3);
Fill t(1) = 1;
Fill t(1) = 2;
.end
assert warning?("Table element was already defined")
*--#] example :
```