### PR TITLE
Fix memory leak in makeinteger

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2668,3 +2668,26 @@ L F = #x;
 .end
 assert compile_error?("Illegal position for #")
 *--#] Issue499_2 :
+*--#[ Issue508 :
+Off statistics;
+cf f g;
+s N;
+on highfirst;
+l F =
+#do i=1,5000
++ f(`i')*(g(1+N/`i')*g(N/`i'-1))^25
+#enddo
+;
+.sort
+makeinteger g;
+id f(N?) = N^50;
+id g(N?) = 1;
+print;
+.end
+#require linux?
+#ulimit -v 8_000_000
+# We assume more memory than a 32bit system can provide
+#require wordsize >= 4
+assert succeeded?
+assert result("F") =~ expr("5000")
+*--#] Issue508 :

--- a/sources/argument.c
+++ b/sources/argument.c
@@ -66,7 +66,7 @@ WORD execarg(PHEAD WORD *term, WORD level)
 	WORD *oldwork = AT.WorkPointer, *oldwork2, scale, renorm;
 	WORD kLCM = 0, kGCD = 0, kGCD2, kkLCM = 0, jLCM = 0, jGCD, sign = 1;
 	int ii, didpolyratfun;
-	UWORD *EAscrat, *GCDbuffer = 0, *GCDbuffer2, *LCMbuffer, *LCMb, *LCMc;
+	UWORD *EAscrat, *GCDbuffer = 0, *GCDbuffer2 = 0, *LCMbuffer = 0, *LCMb = 0, *LCMc = 0;
 	AT.WorkPointer += *term;
 	start = C->lhs[level];
 	AR.Cnumlhs = start[2];
@@ -124,6 +124,16 @@ WORD execarg(PHEAD WORD *term, WORD level)
 /*
   	#[ Argument detection : + argument statement
 */
+/*
+	Allocate Numbers for MakeInteger here, for re-use in case multiple
+	functions are treated in the same term.
+*/
+	if ( type == TYPENORM4 ) {
+		GCDbuffer = NumberMalloc("execarg");
+		GCDbuffer2 = NumberMalloc("execarg");
+		LCMbuffer = NumberMalloc("execarg");
+		LCMb = NumberMalloc("execarg"); LCMc = NumberMalloc("execarg");
+	}
 	didpolyratfun = 0;
 	while ( t < rstop ) {
 		if ( *t >= FUNCTION && functions[*t-FUNCTION].spec <= 0 ) {
@@ -341,11 +351,8 @@ HaveTodo:
 						For normalizing everything to integers we have to
 						determine for all elements of this argument the LCM of
 						the denominators and the GCD of the numerators.
+						The buffers have been allocated already.
 */
-						GCDbuffer = NumberMalloc("execarg");
-						GCDbuffer2 = NumberMalloc("execarg");
-						LCMbuffer = NumberMalloc("execarg");
-						LCMb = NumberMalloc("execarg"); LCMc = NumberMalloc("execarg");
 						r4 = r + *r;
 						r1 = r + ARGHEAD;
 /*
@@ -439,18 +446,10 @@ HaveTodo:
 								r3[jGCD+kLCM] = LCMbuffer[jGCD];
 							k = kLCM;
 						}
-/*						NumberFree(GCDbuffer,"execarg"); GCDbuffer = 0; */
-						NumberFree(GCDbuffer2,"execarg");
-						NumberFree(LCMbuffer,"execarg");
-						NumberFree(LCMb,"execarg"); NumberFree(LCMc,"execarg");
+
 						j = 2*k+1;
 /*
 						Now we have to correct the overall factor
-
-						We have a little problem here.
-						r3 is in GCDbuffer and we returned that.
-						At the same time we still use it.
-						This works as long as each worker has its own TermMalloc
 */
 						if ( scale && ( factor == 0 || *factor > 0 ) )
 							goto ScaledVariety;
@@ -729,6 +728,15 @@ do_shift:
 			}
 		}
 		t += t[1];
+	}
+/*
+		If TYPENORM4, we allocated Number buffers before the above while loop. Free them.
+*/
+	if ( type == TYPENORM4 ) {
+		NumberFree(GCDbuffer,"execarg");
+		NumberFree(GCDbuffer2,"execarg");
+		NumberFree(LCMbuffer,"execarg");
+		NumberFree(LCMb,"execarg"); NumberFree(LCMc,"execarg");
 	}
 	if ( didpolyratfun ) {
 		PolyFunDirty(BHEAD term);
@@ -1737,7 +1745,6 @@ oneterm:;
 	AT.WorkPointer = oldwork;
 	if ( AT.WorkPointer < term + *term ) AT.WorkPointer = term + *term;
 	AT.pWorkPointer = oldppointer;
-	if ( GCDbuffer ) NumberFree(GCDbuffer,"execarg");
 	return(action);
 execargerr:
 	AT.WorkPointer = oldwork;


### PR DESCRIPTION
We need to call NumberFree each loop iteration, not only upon leaving execarg.

This fixes #508 but I think it needs more testing.