### PR TITLE
Better errors when (Sub)SmallExtension is filled.

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2725,9 +2725,10 @@ EOF
 #: SortIOSize 200K
 #: SubSortIOSize 200K
 
-#: SubSmallSize 100K
-#: SubSmallExtension 200K
-#: SubTermsInSmall 5K
+#: SubLargeSize 134400480
+#: SubSmallSize 12800016
+#: SubSmallExtension 19200032
+#: SubTermsInSmall 5008
 
 #define N "30"
 
@@ -2845,19 +2846,17 @@ assert result("F") =~ expr("5000")
 #-
 * Sort which fills SmallExtension:
 
-#: SmallSize 1000K
-#: SmallExtension 1200K
-#: SubSmallSize 1000K
-#: SubSmallExtension 1200K
-#: SubTermsInSmall 2M
+* These are the smallest buffer sizes that are OK for -w4 tform workers
+#: SmallSize 10240064
+#: SmallExtension 15360096
+#: TermsInSmall 100K
 
 Symbol x,n;
-CFunction f,g,prf;
+CFunction g,f,prf;
 
-Local test = (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(100)>);
+Local test = (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(350)>);
 .sort
 
-Off parallel;
 PolyRatFun prf;
 
 Identify f(x?) = prf(n-x,n+x);
@@ -2873,13 +2872,11 @@ assert runtime_error?("Please increase SmallExtension setup parameter.")
 #-
 
 * Sort which fills SubSmallExtension:
-
-#: SmallSize 1000K
-#: SmallExtension 1200K
-#: TermsInSmall 2M
-#: SubSmallSize 1000K
-#: SubSmallExtension 1200K
-#: SubTermsInSmall 2M
+* These are the default sizes at the time of writing:
+#: SubSmallSize 2560016
+#: SubSmallExtension 3840032
+* These are not default:
+#: SubTermsInSmall 100K
 
 Symbol x,n;
 CFunction f,g,prf;
@@ -2904,18 +2901,14 @@ assert runtime_error?("Please increase SubSmallExtension setup parameter.")
 #-
 
 * Sort which fits in SmallExtension, but needs GarbHand
-
-#: SmallSize 1000K
-#: SmallExtension 5090K
-#: TermsInSmall 2M
-#: SubSmallSize 1000K
-#: SubSmallExtension 1200K
-#: SubTermsInSmall 2M
+#: SmallSize 10240064
+#: SmallExtension 20360K
+#: TermsInSmall 100K
 
 Symbol x,n;
-CFunction f,g,prf;
+CFunction g,f,prf;
 
-Local test = (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(100)>);
+Local test = (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(350)>);
 .sort
 
 PolyRatFun prf;
@@ -2930,13 +2923,11 @@ assert succeeded?
 #-
 
 * Sort which fits in SubSmallExtension, but needs GarbHand
-
-#: SmallSize 1000K
-#: SmallExtension 1200K
-#: TermsInSmall 2M
-#: SubSmallSize 1000K
+* These are the default sizes at the time of writing:
+#: SubSmallSize 2560016
+* These are not default:
 #: SubSmallExtension 5090K
-#: SubTermsInSmall 2M
+#: SubTermsInSmall 100K
 
 Symbol x,n;
 CFunction f,g,prf;

--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2841,6 +2841,65 @@ print;
 assert succeeded?
 assert result("F") =~ expr("5000")
 *--#] Issue508 :
+*--#[ Issue512_1 :
+#-
+* Sort which fills SmallExtension:
+
+#: SmallSize 1000K
+#: SmallExtension 1200K
+#: SubSmallSize 1000K
+#: SubSmallExtension 1200K
+#: SubTermsInSmall 2M
+
+Symbol x,n;
+CFunction f,g,prf;
+
+Local test = (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(100)>);
+.sort
+
+Off parallel;
+PolyRatFun prf;
+
+Identify f(x?) = prf(n-x,n+x);
+
+.end
+# Fails due to polynomial size on 32bit builds
+#require wordsize >= 4
+# Runtime errors may freeze ParFORM.
+#pend_if mpi?
+assert runtime_error?("Please increase SmallExtension setup parameter.")
+*--#] Issue512_1 :
+*--#[ Issue512_2 :
+#-
+
+* Sort which fills SubSmallExtension:
+
+#: SmallSize 1000K
+#: SmallExtension 1200K
+#: TermsInSmall 2M
+#: SubSmallSize 1000K
+#: SubSmallExtension 1200K
+#: SubTermsInSmall 2M
+
+Symbol x,n;
+CFunction f,g,prf;
+
+Local test = 1;
+.sort
+
+PolyRatFun prf;
+Term;
+	Multiply (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(100)>);
+	Identify f(x?) = prf(n-x,n+x);
+EndTerm;
+
+.end
+# Fails due to polynomial size on 32bit builds
+#require wordsize >= 4
+# Runtime errors may freeze ParFORM.
+#pend_if mpi?
+assert runtime_error?("Please increase SubSmallExtension setup parameter.")
+*--#] Issue512_2 :
 *--#[ Issue525 :
 #:threadbucketsize 5
 #:processbucketsize 5

--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2900,6 +2900,61 @@ EndTerm;
 #pend_if mpi?
 assert runtime_error?("Please increase SubSmallExtension setup parameter.")
 *--#] Issue512_2 :
+*--#[ Issue512_3 :
+#-
+
+* Sort which fits in SmallExtension, but needs GarbHand
+
+#: SmallSize 1000K
+#: SmallExtension 5090K
+#: TermsInSmall 2M
+#: SubSmallSize 1000K
+#: SubSmallExtension 1200K
+#: SubTermsInSmall 2M
+
+Symbol x,n;
+CFunction f,g,prf;
+
+Local test = (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(100)>);
+.sort
+
+PolyRatFun prf;
+Identify f(x?) = prf(n-x,n+x);
+
+.end
+# Fails due to polynomial size on 32bit builds
+#require wordsize >= 4
+assert succeeded?
+*--#] Issue512_3 :
+*--#[ Issue512_4 :
+#-
+
+* Sort which fits in SubSmallExtension, but needs GarbHand
+
+#: SmallSize 1000K
+#: SmallExtension 1200K
+#: TermsInSmall 2M
+#: SubSmallSize 1000K
+#: SubSmallExtension 5090K
+#: SubTermsInSmall 2M
+
+Symbol x,n;
+CFunction f,g,prf;
+
+Local test = 1;
+.sort
+
+PolyRatFun prf;
+Term;
+	Multiply (<f(1)>+...+<f(150)>)*(<g(1)>+...+<g(100)>);
+	Identify f(x?) = prf(n-x,n+x);
+EndTerm;
+
+.end
+# Fails due to polynomial size on 32bit builds
+#require wordsize >= 4
+assert succeeded?
+*--#] Issue512_4 :
 *--#[ Issue525 :
 #:threadbucketsize 5
 #:processbucketsize 5

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -2234,11 +2234,21 @@ WORD AddPoly(PHEAD WORD **ps1, WORD **ps2)
 					TalToLine((UWORD)(*s2++)); TokenToLine((UBYTE *)"  ");
 				}
 				FiniLine();
-				MesPrint("Please increase SmallExtension in %s",setupfilename);
+				if ( AR.sLevel > 0 ) {
+					MesPrint("Please increase SubSmallExtension setup parameter.");
+				}
+				else {
+					MesPrint("Please increase SmallExtension setup parameter.");
+				}
 				MUNLOCK(ErrorMessageLock);
 #else
 				MLOCK(ErrorMessageLock);
-				MesPrint("Please increase SmallExtension in %s",setupfilename);
+				if ( AR.sLevel > 0 ) {
+					MesPrint("Please increase SubSmallExtension setup parameter.");
+				}
+				else {
+					MesPrint("Please increase SmallExtension setup parameter.");
+				}
 				MUNLOCK(ErrorMessageLock);
 #endif
 				Terminate(-1);

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -51,6 +51,12 @@
 #define GZIPDEBUG
 */
 #define NEWSPLITMERGE
+/* Comment to turn off Timsort in SplitMerge for debugging: */
+#define NEWSPLITMERGETIMSORT
+/* During SplitMerge, print pointer array state on entry. Very spammy, for debugging. */
+/* #define SPLITMERGEDEBUG */
+/* Debug printing for GarbHand */
+/* #define TESTGARB */
 
 #include "form3.h"
 
@@ -3318,6 +3324,21 @@ LONG SplitMerge(PHEAD WORD **Pointer, LONG number)
 	WORD **pp3, **pp1, **pp2, **pptop;
 	LONG i, newleft, newright, split;
 
+#ifdef SPLITMERGEDEBUG
+	/* Print current array state on entry. */
+	printf("%4ld: ", number);
+	for (int ii = 0; ii < S->sTerms; ii++) {
+		if ( (S->sPointer)[ii] ) {
+			printf("%4d ", (unsigned)(S->sPointer[ii]-S->sBuffer));
+		}
+		else {
+			printf(".... ");
+		}
+	}
+	printf("\n");
+	fflush(stdout);
+#endif
+
 	if ( number < 2 ) return(number);
 	if ( number == 2 ) {
 		pp1 = Pointer; pp2 = pp1 + 1;
@@ -3380,6 +3401,7 @@ LONG SplitMerge(PHEAD WORD **Pointer, LONG number)
 	AN.InScratch = newleft;
 	pp1 = AN.SplitScratch; pp2 = Pointer + split; pp3 = Pointer;
 
+#ifdef NEWSPLITMERGETIMSORT
 /*
 		An improvement in the style of Timsort
 */
@@ -3415,6 +3437,7 @@ LONG SplitMerge(PHEAD WORD **Pointer, LONG number)
 			break;
 		}
 	}
+#endif
 
 	while ( newleft > 0 && newright > 0 ) {
 		if ( ( i = CompareTerms(BHEAD *pp1,*pp2,(WORD)0) ) < 0 ) {
@@ -3454,6 +3477,21 @@ LONG SplitMerge(PHEAD WORD **Pointer, LONG number)
 	WORD **pp3, **pp1, **pp2;
 	LONG nleft, nright, i, newleft, newright;
 	WORD **pptop;
+
+#ifdef SPLITMERGEDEBUG
+	/* Print current array state on entry. */
+	printf("%4ld: ", number);
+	for (int ii = 0; ii < S->sTerms; ii++) {
+		if ( (S->sPointer)[ii] ) {
+			printf("%4d ", (unsigned)(S->sPointer[ii]-S->sBuffer));
+		}
+		else {
+			printf(".... ");
+		}
+	}
+	printf("\n");
+	fflush(stdout);
+#endif
 
 	if ( number < 2 ) return(number);
 	if ( number == 2 ) {


### PR DESCRIPTION
Previously, FORM warns only about SmallExtension, even if it is a sub-buffer sort.

This prompts the user to adjust the wrong buffer in the setup.

Fixes #512 