### PR TITLE
Make sure SIOsize is >= MaxTermSize

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2277,6 +2277,29 @@ assert succeeded?
 assert result("test", -2) =~ expr("f(0)*g(2)")
 assert result("test", -1) =~ expr("h(2,0)")
 *--#] Issue277 : 
+*--#[ Issue292 :
+#-
+#: MaxTermSize 16K
+#: SubTermsInSmall 800
+#: SubSortIOSize 8K
+
+CFunction f;
+AutoDeclare Symbol x;
+
+Local test = x - f(x);
+.sort
+
+Identify x = (x1+...+x11)^4;
+Argument f;
+	Identify x = (x1+...+x11)^4;
+EndArgument;
+.sort
+
+Identify f(x?) = x;
+Print test;
+.end
+assert result("test") =~ expr("0")
+*--#] Issue292 :
 *--#[ Issue307 :
 * replace_ with nested CFunctions crashes
 S N,j1;

--- a/sources/setfile.c
+++ b/sources/setfile.c
@@ -604,6 +604,8 @@ int AllocSetups(VOID)
 	AM.SMaxFpatches = sp->value;
 	sp = GetSetupPar((UBYTE *)"subsortiosize");
 	AM.SIOsize = sp->value;
+	/* As for IOsize, make sure SIOsize is at least as large as AM.MaxTer. */
+	if ( AM.SIOsize < AM.MaxTer ) { AM.SIOsize = AM.MaxTer; sp->value = AM.SIOsize; }
 	sp = GetSetupPar((UBYTE *)"spectatorsize");
 	AM.SpectatorSize = sp->value;
 /*

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -957,7 +957,12 @@ LONG EndSort(PHEAD WORD *buffer, int par)
 						UNLOCK(newout->pthreadslock);
 #endif
 					}
-					else if ( newout->handle >= 0 ) {	/* output too large */
+					else if ( newout->handle >= 0 ) {
+/*
+						We land here if par == 1 (function arg sort) and PutOut has created a file.
+						This means that the term is larger than SIOsize, which we ensure is at least
+						as large as MaxTermSize in setfile.c. Thus we know already that the term won't fit.
+*/
 TooLarge:
 						MLOCK(ErrorMessageLock);
 						MesPrint("(1)Output should fit inside a single term. Increase MaxTermSize?");


### PR DESCRIPTION
Various buffers in AllocSort depend on the IOsize parameter. At the
main level this is >= MaxTermSize, but this was not the case when
sorting function args, dollar variables.

Fixes the examples in #80 #292