### PR TITLE
Change EndSort type for transform statements

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -1694,7 +1694,22 @@ P;
 .end
 assert succeeded?
 assert result("F") =~ expr("rat(1,ep^2 + 2*ep + 1)")
-*--#] Issue180 : 
+*--#] Issue180 :
+*--#[ Issue183 :
+#: MaxTermSize 16K
+#: SubTermsInSmall 800
+
+CF f;
+Auto S x;
+L F = f(<x1+x2+x3+x4>,...,<x6+x7+x8+x9>);
+*repeat id f(x1?,x2?,?a) = f(x1*x2,?a);  * error: Sorted function argument...
+transform f,mulargs(1,last);  * silent crash
+P;
+.end
+# Runtime errors may freeze ParFORM.
+#pend_if mpi?
+assert runtime_error?("Term too complex during normalization")
+*--#] Issue183 :
 *--#[ Issue185 :
 * Wrong result of content_
 
@@ -2002,6 +2017,29 @@ Symbol x;
 .end
 assert succeeded?
 *--#] Issue222 : 
+*--#[ Issue230 :
+#-
+#: MaxTermSize 16K
+#: SubTermsInSmall 800
+
+
+Off Statistics;
+
+Symbol x1,...,x11;
+CFunction f;
+
+Local test = f(x1+...+x11) - (x1+...+x11)^4;
+Identify f(x1?) = f(x1,x1,x1,x1);
+.sort
+
+Transform f mulargs(1,last);
+Identify f(x1?) = x1;
+
+Print +s;
+.end
+assert succeeded?
+assert result("test") =~ expr("0")
+*--#] Issue230 :
 *--#[ Issue231 :
 Symbol x,y,z;
 Local F = x + y + x*z;

--- a/sources/transform.c
+++ b/sources/transform.c
@@ -840,7 +840,7 @@ returnvalues:;
 							return(-1);
 						}
 						newterm = AT.WorkPointer;
-						if ( EndSort(BHEAD newterm,0) < 0 ) {}
+						if ( EndSort(BHEAD newterm,1) < 0 ) {}
 						if ( ( *newterm && *(newterm+*newterm) != 0 ) || *newterm == 0 ) {
 							MLOCK(ErrorMessageLock);
 							MesPrint("&yes/no information in islyndon/tolyndon does not evaluate into a single term");
@@ -1379,7 +1379,7 @@ WORD RunReplace(PHEAD WORD *fun, WORD *args, WORD *info)
 		return(-1);
 	}
 	newterm = AT.WorkPointer;
-	if ( EndSort(BHEAD newterm,0) < 0 ) {}
+	if ( EndSort(BHEAD newterm,1) < 0 ) {}
 	if ( ( *newterm && *(newterm+*newterm) != 0 ) || *newterm == 0 ) {
 		MLOCK(ErrorMessageLock);
 		MesPrint("&information in replace transformation does not evaluate into a single term");
@@ -1641,7 +1641,7 @@ getthisone:;
 							return(-1);
 						}
 						term4 = AT.WorkPointer;
-						if ( EndSort(BHEAD term4,0) < 0 ) {}
+						if ( EndSort(BHEAD term4,1) < 0 ) {}
 						if ( ( *term4 && *(term4+*term4) != 0 ) || *term4 == 0 ) {
 							MLOCK(ErrorMessageLock);
 							MesPrint("&information in replace transformation does not evaluate into a single term");
@@ -1768,7 +1768,7 @@ dothisnow:;
 				return(-1);
 			}
 			term4 = AT.WorkPointer;
-			if ( EndSort(BHEAD term4,0) < 0 ) {}
+			if ( EndSort(BHEAD term4,1) < 0 ) {}
 			if ( ( *term4 && *(term4+*term4) != 0 ) || *term4 == 0 ) {
 				MLOCK(ErrorMessageLock);
 				MesPrint("&information in replace transformation does not evaluate into a single term");
@@ -2737,7 +2737,7 @@ WORD RunAddArg(PHEAD WORD *fun, WORD *args)
 		}
 		n++;
 	}
-	if ( EndSort(BHEAD tstop+ARGHEAD,0) ) return(-1);
+	if ( EndSort(BHEAD tstop+ARGHEAD,1) ) return(-1);
 	num = 0;
 	f2 = tstop+ARGHEAD;
 	while ( *f2 ) { f2 += *f2; num++; }
@@ -2883,7 +2883,7 @@ WORD RunMulArg(PHEAD WORD *fun, WORD *args)
 	NewSort(BHEAD0);
 	Generator(BHEAD scratch,AR.Cnumlhs);
 	newterm = AT.WorkPointer;
-	EndSort(BHEAD newterm+ARGHEAD,0);
+	EndSort(BHEAD newterm+ARGHEAD,1);
 	C->Pointer = C->Buffer+oldcpointer_pos;
 	C->numrhs = nb;
 	w = newterm+ARGHEAD; while ( *w ) w += *w;


### PR DESCRIPTION
Since the transform statements are sorting into the workspace, and might have to merge patches, make them use a par=1 EndSort. This commit makes this change for all transform statements, though only mularg is going to produce an explosion of terms here.

This fixes #230 and causes #183 to crash with a useful error (Term too complex during normalization).