### PR TITLE
Try to create the sort file at startup.

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -1135,3 +1135,13 @@ Print +s;
 assert succeeded?
 assert result("F") =~ expr("0");
 *--#] Sortrealloc_2 :
+*--#[ TempSortDir :
+#: TempSortDir bad/path
+Local test = 1;
+.end
+if mpi?
+  assert runtime_error?("Could not create sort file: bad/path/0formxxx.sor")
+else
+  assert runtime_error?("Could not create sort file: bad/path/xformxxx.sor")
+end
+*--#] TempSortDir :

--- a/sources/startup.c
+++ b/sources/startup.c
@@ -802,6 +802,17 @@ classic:;
 	s[-2] = 'o'; *s = 0;
 	}
 /*
+	Try to create the sort file already, so we can Terminate earlier if this fails.
+*/
+	if ( ( AM.S0->file.handle = CreateFile((char *)AM.S0->file.name) ) < 0 ) {
+		MesPrint("Could not create sort file: %s", AM.S0->file.name);
+		Terminate(-1);
+	};
+	/* Close and clean up the test file */
+	CloseFile(AM.S0->file.handle);
+	AM.S0->file.handle = -1;
+	remove(AM.S0->file.name);
+/*
 	With the stage4 and scratch file names we have to be a bit more careful.
 	They are to be allocated after the threads are initialized when there
 	are threads of course.


### PR DESCRIPTION
If a bad path for FORMTMPSORT is specified, FORM doesn't notice until it tries to create a sort file and can't. In principle one can create a script which takes a long time to reach this point.

Try to create the file immediately at startup, and Terminate if this fails.