### PR TITLE
ParFORM: fix #525

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2841,6 +2841,23 @@ print;
 assert succeeded?
 assert result("F") =~ expr("5000")
 *--#] Issue508 :
+*--#[ Issue525 :
+#:threadbucketsize 5
+#:processbucketsize 5
+S x;
+L F = (1-x)^100;
+L F1 = 1;
+L F2 = 1;
+.sort
+#define x "0"
+if (expression(F1)) redefine x "1";
+.sort
+id x = `x';
+P F;
+.end
+assert succeeded?
+assert result("F") =~ expr("0")
+*--#] Issue525 :
 *--#[ Issue563 :
 #: SubTermsInSmall 50
 

--- a/sources/execute.c
+++ b/sources/execute.c
@@ -875,11 +875,6 @@ WORD DoExecute(WORD par, WORD skip)
 		RetCode = PF_BroadcastModifiedDollars();
 		if ( RetCode ) return RetCode;
 	}
-	/* Broadcast redefined preprocessor variables. */
-	if ( AC.numpfirstnum > 0 ) {
-		RetCode = PF_BroadcastRedefinedPreVars();
-		if ( RetCode ) return RetCode;
-	}
 	/* Broadcast the list of objects converted to symbols in AM.sbufnum. */
 	if ( AC.topolynomialflag & TOPOLYNOMIALFLAG ) {
 		RetCode = PF_BroadcastCBuf(AM.sbufnum);

--- a/sources/parallel.c
+++ b/sources/parallel.c
@@ -1768,6 +1768,11 @@ int PF_Processor(EXPRESSIONS e, WORD i, WORD LastExpression)
 			/* Now handle redefined preprocessor variables. */
 			if ( AC.numpfirstnum > 0 ) PF_UnpackRedefinedPreVars();
 		}
+		/* Broadcast redefined preprocessor variables. */
+		if ( AC.numpfirstnum > 0 ) {
+			int RetCode = PF_BroadcastRedefinedPreVars();
+			if ( RetCode ) return RetCode;
+		}
 		if ( ! AC.OldParallelStats ) {
 			/* Now we can calculate AT.SS->GenTerms from the statistics of the slaves. */
 			LONG genterms = 0;
@@ -1917,6 +1922,11 @@ int PF_Processor(EXPRESSIONS e, WORD i, WORD LastExpression)
 		/* Now handle redefined preprocessor variables. */
 		if ( AC.numpfirstnum > 0 ) PF_PackRedefinedPreVars();
 		PF_LongSingleSend(MASTER, PF_ENDSORT_MSGTAG);
+		/* Broadcast redefined preprocessor variables. */
+		if ( AC.numpfirstnum > 0 ) {
+			int RetCode = PF_BroadcastRedefinedPreVars();
+			if ( RetCode ) return RetCode;
+		}
 /*
 			#] Collect (stats,prepro...) : 
 


### PR DESCRIPTION
This fixes #525 by moving the broadcast of the redefined preprocessor variables to after processing each expression, rather than at the end of the module.