### PR TITLE
Fix WorkSpace issues with expression optimization

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2943,3 +2943,18 @@ Local F = rat(f,1);
 #pend_if mpi?
 assert runtime_error?("ERROR: polynomials and polyratfuns must contain symbols only")
 *--#] Issue567_3f :
+*--#[ PullReq535 :
+* This test requires more than the specified 50K workspace.
+#:maxtermsize 200
+#:workspace 50000
+S x1,...,x19;
+L F = (x1+...+x19)^4;
+Format O1;
+.sort
+#optimize F
+L G = `optimvalue_';
+P G;
+.end
+assert succeeded?
+assert result("G") =~ expr("389")
+*--#] PullReq535 :

--- a/sources/optimize.cc
+++ b/sources/optimize.cc
@@ -4453,15 +4453,19 @@ WORD generate_expression (WORD exprnr) {
 	// scan for the original expression (marked by *t<0) and give the
 	// terms to Generator
 	WORD *t = AO.OptimizeResult.code;
-    {
+	{
 		WORD old = AR.Cnumlhs; AR.Cnumlhs = 0;
+		// We can use the remaining part of the WorkSpace for every term that
+		// goes through Generator. We have WorkSpace problems here if we use
+		// the (modified) AT.WorkPointer every time in the loop.
+		WORD* currentWorkPointer = AT.WorkPointer;
 		while (*t!=0) {
 			bool is_expr = *t < 0;
 			t++;
 			while (*t!=0) {
 				if (is_expr) {
-					memcpy(AT.WorkPointer, t, *t*sizeof(WORD));
-					Generator(BHEAD AT.WorkPointer, C->numlhs);
+					memcpy(currentWorkPointer, t, *t*sizeof(WORD));
+					Generator(BHEAD currentWorkPointer, C->numlhs);
 				}
 				t+=*t;
 			}


### PR DESCRIPTION
Here are two changes to make the optimizer easier to use.

The first is to dynamically allocate memory in `Horner_tree`, if the `WorkSpace` does not have enough space. There is no particular reason that the workspace should be used for the sort, here, other than that it exists, and might have capacity.

The second, is to re-use the same `WorkPointer` for every call of `Generator` when the optimized expression is placed into FORM's output. `Generator` modifies `AT.WorkPointer` internally, so each term which was added here was placed further and further into the buffer, unnecessarily.

In principle, if you arrive in `generate_expression` with a very-nearly full WorkSpace there could still be a crash. But this should be rare (?) .

These changes pass `pySecDec`'s test suite.