### PR TITLE
Optionally reallocate large+small buffer after each module

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -1111,3 +1111,27 @@ format C;
 assert succeeded?
 assert !(file("out.c") =~ /[_] [+]=  /)
 *--#] Issue392_ContinuationLines_0 :
+*--#[ Sortrealloc_1 :
+On sortreallocate;
+Symbol x,y;
+Local F = (x+y)^10;
+.sort
+Identify x = - y;
+.sort
+Print +s;
+.end
+assert succeeded?
+assert result("F") =~ expr("0");
+*--#] Sortrealloc_1 :
+*--#[ Sortrealloc_2 :
+Symbol x,y;
+Local F = (x+y)^10;
+.sort
+#sortreallocate
+Identify x = - y;
+.sort
+Print +s;
+.end
+assert succeeded?
+assert result("F") =~ expr("0");
+*--#] Sortrealloc_2 :

--- a/doc/manual/prepro.tex
+++ b/doc/manual/prepro.tex
@@ -1936,6 +1936,22 @@ definitions would contain the old extra symbols. The result would be
 incorrect.
 
 %--#] skipextrasymbols : 
+%--#[ sortreallocate :
+
+\section{\#sortreallocate}
+\label{presortreallocate}
+
+\noindent Syntax:
+
+\#sortreallocate\index{\#sortreallocate}
+
+\noindent See also ``On sortreallocate;'' (\ref{substaon}).
+
+\noindent Reallocates the small and large buffer (also on the worker threads)
+at the end of the current module. In some cases this can significantly reduce
+\FORM's memory usage as measured by ``resident set size''.
+
+%--#] sortreallocate : 
 %--#[ switch :
 
 \section{\#switch}

--- a/doc/manual/setup.tex
+++ b/doc/manual/setup.tex
@@ -439,6 +439,14 @@ the buffers of the master thread. The workers each get basically buffers
 with 1/N times the size of the buffer of the master. This may get made a 
 bit bigger when potential conflicts with MaxTermSize occur.
 
+The (typically) largest buffers (the small and large buffers) may be reallocated
+at the end of a single module (see \#sortreallocate (\ref{presortreallocate})) or
+at the end of each module (see ``On sortreallocate;'' (\ref{substaon})). In some
+cases this can significantly reduce \FORM's memory usage as measured by
+``resident set size''. For programs which consist of a large number of very
+quickly-running modules, this can incur a noticable performance penalty if performed
+every module.
+
 The default settings are
 \begin{center}
 \begin{tabular}{lrrr}

--- a/doc/manual/statements.tex
+++ b/doc/manual/statements.tex
@@ -3836,6 +3836,10 @@ printed. This is the default.}
 \rightvitem{13cm}{Takes the writing of the statistics back from shorthand 
 mode to the regular statistics mode in which each statistics messages takes 
 three lines of text and one blank line.}
+
+\leftvitem{3.5cm}{sortreallocate\index{off!sortreallocate}}
+\rightvitem{13cm}{Turns off the reallocation of the small and large buffer
+at the end of each module.}
  
 \leftvitem{3.5cm}{threadloadbalancing\index{off!threadloadbalancing}}
 \rightvitem{13cm}{\vspace{1.5ex}Disables the loadbalancing mechanism of 
@@ -4000,6 +4004,14 @@ which the complete statistics are written on a single line only.}
  
 \leftvitem{3.5cm}{shortstats\index{on!shortstats}}
 \rightvitem{13cm}{Same as `On shortstatistics'.}
+
+\leftvitem{3.5cm}{sortreallocate\index{on!sortreallocate}}
+\rightvitem{13cm}{Reallocate the small and large buffer (also on the worker
+threads) at the end of every module. In some cases this can significantly reduce
+\FORM's memory usage as measured by ``resident set size''. For programs which
+consist of a large number of very quickly-running modules, this can incur a
+noticable performance penalty. See also \#sortreallocate (\ref{presortreallocate})
+for a single-module version of this feature.}
 
 \leftvitem{3.5cm}{statistics\index{on!statistics}}
 \rightvitem{13cm}{Turns the writing of runtime statistics on. This is the 

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -628,6 +628,14 @@ int CoOff(UBYTE *s)
 				AC.TestValue = 0;
 			}
 		}
+		else if ( StrICont(t,(UBYTE *)"sortreallocate") == 0 ) {
+			if ( AC.SortReallocateFlag == 2 ) {
+				/* The flag has been set by #sortreallocate, and it was off before. Leave it as 2,
+				   so that the reallocation still happens in the current module. It will be turned
+				   off after the reallocation is done. */
+				return(0);
+			}
+		}
 		*s = c;
 	 	*onoffoptions[i].var = onoffoptions[i].flags; 
 		AR.SortType = AC.SortType;

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -136,6 +136,7 @@ static KEYWORDV onoffoptions[] = {
 	,{"oldgcd", 		&(AC.OldGCDflag),	1,	0}
 	,{"innertest",      &(AC.InnerTest),  1,  0}
 	,{"wtimestats",     &(AC.WTimeStatsFlag),  1,  0}
+	,{"sortreallocate",	&(AC.SortReallocateFlag), 1, 0}
 };
 
 static WORD one = 1;

--- a/sources/declare.h
+++ b/sources/declare.h
@@ -957,6 +957,7 @@ extern int    DoPrePrintTimes(UBYTE *);
 extern int    DoPreWrite(UBYTE *);
 extern int    DoPreClose(UBYTE *);
 extern int    DoPreRemove(UBYTE *);
+extern int    DoPreSortReallocate(UBYTE *);
 extern int    DoCommentChar(UBYTE *);
 extern int    DoPrcExtension(UBYTE *);
 extern int    DoPreReset(UBYTE *);

--- a/sources/declare.h
+++ b/sources/declare.h
@@ -1451,6 +1451,7 @@ extern int    MasterWaitThread(int);
 extern void   WakeupMasterFromThread(int,int);
 extern int    LoadReadjusted(VOID);
 extern int    IniSortBlocks(int);
+extern int    UpdateSortBlocks(int);
 extern int    TreatIndexEntry(PHEAD LONG);
 extern WORD   GetTerm2(PHEAD WORD *);
 extern void	SetHideFiles(VOID);

--- a/sources/execute.c
+++ b/sources/execute.c
@@ -1046,26 +1046,10 @@ if ( AC.SwitchInArray > 0 ) {
 	  AC.MultiBracketBuf = 0;
 	}
 
-	/*	Reallocate the sort buffers to reduce resident set usage */
-	/* AT.SS is the same as AT.S0 here */
-	SORTING* S = AT.S0;
-	M_free(S->lBuffer, "SortReallocate lBuffer+sBuffer");
-	S->lBuffer = Malloc1(sizeof(*(S->lBuffer))*(S->LargeSize+S->SmallEsize), "SortReallocate lBuffer+sBuffer");
-	S->lTop = S->lBuffer+S->LargeSize;
-	S->sBuffer = S->lTop;
-	if ( S->LargeSize == 0 ) { S->lBuffer = 0; S->lTop = 0; }
-	S->sTop = S->sBuffer + S->SmallSize;
-	S->sTop2 = S->sBuffer + S->SmallEsize;
-	S->sHalf = S->sBuffer + (LONG)((S->SmallSize+S->SmallEsize)>>1);
-
-#ifdef WITHPTHREADS
-	/* We have to re-set the pointers into master lBuffer in the SortBlocks */
-	UpdateSortBlocks(AM.totalnumberofthreads-1);
-
-	/* The SortBots do not have a real sort buffer to reallocate. */
-	/* AB[0] has been reallocated above already. */
-	for ( i = 1; i < AM.totalnumberofthreads; i++ ) {
-		SORTING* S = AB[i]->T.S0;
+	if ( AC.SortReallocateFlag ) {
+		/* Reallocate the sort buffers to reduce resident set usage */
+		/* AT.SS is the same as AT.S0 here */
+		SORTING* S = AT.S0;
 		M_free(S->lBuffer, "SortReallocate lBuffer+sBuffer");
 		S->lBuffer = Malloc1(sizeof(*(S->lBuffer))*(S->LargeSize+S->SmallEsize), "SortReallocate lBuffer+sBuffer");
 		S->lTop = S->lBuffer+S->LargeSize;
@@ -1074,8 +1058,26 @@ if ( AC.SwitchInArray > 0 ) {
 		S->sTop = S->sBuffer + S->SmallSize;
 		S->sTop2 = S->sBuffer + S->SmallEsize;
 		S->sHalf = S->sBuffer + (LONG)((S->SmallSize+S->SmallEsize)>>1);
-	}
+
+#ifdef WITHPTHREADS
+		/* We have to re-set the pointers into master lBuffer in the SortBlocks */
+		UpdateSortBlocks(AM.totalnumberofthreads-1);
+
+		/* The SortBots do not have a real sort buffer to reallocate. */
+		/* AB[0] has been reallocated above already. */
+		for ( i = 1; i < AM.totalnumberofthreads; i++ ) {
+			SORTING* S = AB[i]->T.S0;
+			M_free(S->lBuffer, "SortReallocate lBuffer+sBuffer");
+			S->lBuffer = Malloc1(sizeof(*(S->lBuffer))*(S->LargeSize+S->SmallEsize), "SortReallocate lBuffer+sBuffer");
+			S->lTop = S->lBuffer+S->LargeSize;
+			S->sBuffer = S->lTop;
+			if ( S->LargeSize == 0 ) { S->lBuffer = 0; S->lTop = 0; }
+			S->sTop = S->sBuffer + S->SmallSize;
+			S->sTop2 = S->sBuffer + S->SmallEsize;
+			S->sHalf = S->sBuffer + (LONG)((S->SmallSize+S->SmallEsize)>>1);
+		}
 #endif
+	}
 
 	return(RetCode);
 }

--- a/sources/execute.c
+++ b/sources/execute.c
@@ -1078,6 +1078,11 @@ if ( AC.SwitchInArray > 0 ) {
 		}
 #endif
 	}
+	if ( AC.SortReallocateFlag == 2 ) {
+		/* The Flag was set for a single module by the preprocessor #sortreallocate,
+		   so turn it off again. */
+		AC.SortReallocateFlag = 0;
+	}
 
 	return(RetCode);
 }

--- a/sources/pre.c
+++ b/sources/pre.c
@@ -104,6 +104,7 @@ static KEYWORD precommands[] = {
 	,{"setrandom"    , DoSetRandom    , 0, 0}
 	,{"show"         , DoPreShow      , 0, 0}
 	,{"skipextrasymbols" , DoSkipExtraSymbols , 0, 0}
+	,{"sortreallocate", DoPreSortReallocate , 0, 0}
 #ifdef WITHFLOAT
     ,{"startfloat"   , DoStartFloat   , 0, 0}
 #endif
@@ -3777,6 +3778,23 @@ int DoPrePrintTimes(UBYTE *s)
 
 /*
  		#] DoPrePrintTimes : 
+		#[ DoPreSortReallocate :
+*/
+
+int DoPreSortReallocate(UBYTE *s)
+{
+	DUMMYUSE(s);
+	if ( AC.SortReallocateFlag == 0 ) {
+		/* Currently off, so set to 2. Then the reallocation code knows the flag was
+		   set here, since "On sortreallocate;" sets it to 1. */
+		AC.SortReallocateFlag = 2;
+	}
+	/* If the flag is already on, do nothing. */
+	return(0);
+}
+
+/*
+		#] DoPreSortReallocate :
  		#[ DoPreAppend :
 
 		Syntax:

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -1867,6 +1867,7 @@ struct C_const {
     int     MemDebugFlag;          /* Only used when MALLOCDEBUG in tools.c */
     int     OldGCDflag;
     int     WTimeStatsFlag;
+    int     SortReallocateFlag;    /* Controls reallocation of large+small buffer at module end */
 	int     doloopstacksize;
 	int     dolooplevel;
     int     CheckpointFlag;        /**< Tells preprocessor whether checkpoint code must executed.

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -1867,7 +1867,10 @@ struct C_const {
     int     MemDebugFlag;          /* Only used when MALLOCDEBUG in tools.c */
     int     OldGCDflag;
     int     WTimeStatsFlag;
-    int     SortReallocateFlag;    /* Controls reallocation of large+small buffer at module end */
+    int     SortReallocateFlag;    /* Controls reallocation of large+small buffer at module end.
+                                        0 : Off
+                                        1 : On, every module (set by On sortreallocate;)
+                                        2 : On, single module (set by #sortreallocate) */
 	int     doloopstacksize;
 	int     dolooplevel;
     int     CheckpointFlag;        /**< Tells preprocessor whether checkpoint code must executed.


### PR DESCRIPTION
This is a test of a request from @msloechner , which makes FORM's resident set size better track its actual memory usage. This comes on top of the split allocations branch, since it only deals with the largest buffer. Since FORM allocates its buffers and keeps them for the whole run, the apparent memory usage remains constant after a "peak". If the OS is under memory pressure it will swap pages, but they might be pages that FORM actually isn't using any more.

It seems there are two ways to do it: free and re-allocate the buffer, or use `madvise` to specify `MADV_DONTNEED`. Both have the same effect and have about the same performance, but there is an impact of more than 10% compared to doing nothing. This shouldn't be done by default, and maybe never "every module". (However, the longer each module takes, with lots of disk access during sorting, etc, the less the performance impact will be).

The options could be, a preprocessor statement like `#reallocatesort` which must be specified when the user really wants this (say, after a heavy module) or maybe just `On reallocatesort;` to enable it for every module which follows. Any thoughts?

@msloechner , can you test this and see if it helps your multiple concurrent jobs scenario? I could also see it being useful when running FORM on cluster machines which kill jobs based on RSS: both of these commits have a lower peak RSS in my tests compared to the original behaviour.

Here is a small MINCER performance test for `orig` (unmodified form), `split` (checking the split allocations have no impact) `realloc` (the first commit) and `madv` (the second):
```
Benchmark 1: nice -n -10 ../bin/tform-test-SR-orig -w12 calcdia.frm > calcdia.log1
  Time (mean ± σ):     16.686 s ±  0.216 s    [User: 152.647 s, System: 1.269 s]
  Range (min … max):   16.252 s … 16.909 s    8 runs

Benchmark 2: nice -n -10 ../bin/tform-test-SR-split -w12 calcdia.frm > calcdia.log2
  Time (mean ± σ):     16.718 s ±  0.320 s    [User: 152.869 s, System: 1.197 s]
  Range (min … max):   16.166 s … 17.113 s    8 runs

Benchmark 3: nice -n -10 ../bin/tform-test-SR-realloc -w12 calcdia.frm > calcdia.log3
  Time (mean ± σ):     18.932 s ±  0.154 s    [User: 156.316 s, System: 6.020 s]
  Range (min … max):   18.730 s … 19.200 s    8 runs

Benchmark 4: nice -n -10 ../bin/tform-test-SR-madv -w12 calcdia.frm > calcdia.log4
  Time (mean ± σ):     18.942 s ±  0.248 s    [User: 157.591 s, System: 5.870 s]
  Range (min … max):   18.585 s … 19.308 s    8 runs

Summary
  nice -n -10 ../bin/tform-test-SR-orig -w12 calcdia.frm > calcdia.log1 ran
    1.00 ± 0.02 times faster than nice -n -10 ../bin/tform-test-SR-split -w12 calcdia.frm > calcdia.log2
    1.13 ± 0.02 times faster than nice -n -10 ../bin/tform-test-SR-realloc -w12 calcdia.frm > calcdia.log3
    1.14 ± 0.02 times faster than nice -n -10 ../bin/tform-test-SR-madv -w12 calcdia.frm > calcdia.log4
```
Here is the RSS profile of this test:
![rss](https://github.com/vermaseren/form/assets/12031624/5a10c1ef-f426-4bf1-8e2e-b995c5f24b27)
