### PR TITLE
Adapting code to GCC-14

### DIFF
--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -122,19 +122,19 @@ static KEYWORDV onoffoptions[] = {
 	,{"threadsortfilesynch",&(AC.ThreadSortFileSynch),1,  0}
 	,{"threadstats",	&(AC.ThreadStats),1,	0}
 	,{"finalstats",	    &(AC.FinalStats),1,	0}
-	,{"fewerstats",		&(AC.ShortStatsMax),	10,		0}
-	,{"fewerstatistics",&(AC.ShortStatsMax),	10,		0}
+	,{"fewerstats",		(int *)&(AC.ShortStatsMax),	10,		0}
+	,{"fewerstatistics",	(int *)&(AC.ShortStatsMax),	10,		0}
 	,{"processstats",	&(AC.ProcessStats),1,	0}
 	,{"oldparallelstats",&(AC.OldParallelStats),1,0}
 	,{"parallel",	    &(AC.parallelflag),PARALLELFLAG,NOPARALLEL_USER}
 	,{"nospacesinnumbers",&(AO.NoSpacesInNumbers),1,0}
-	,{"indentspace",    &(AO.IndentSpace),INDENTSPACE,0}
+	,{"indentspace",    (int *)&(AO.IndentSpace),INDENTSPACE,0}
 	,{"totalsize",		&(AM.PrintTotalSize),	1,	0}
 	,{"flag",			(int *)&(AC.debugFlags),	1,	0}
 	,{"oldfactarg",		&(AC.OldFactArgFlag),	1,	0}
 	,{"memdebugflag",	&(AC.MemDebugFlag),	1,	0}
 	,{"oldgcd", 		&(AC.OldGCDflag),	1,	0}
-	,{"innertest",      &(AC.InnerTest),  1,  0}
+	,{"innertest",      (int *)&(AC.InnerTest),  1,  0}
 	,{"wtimestats",     &(AC.WTimeStatsFlag),  1,  0}
 };
 

--- a/sources/float.c
+++ b/sources/float.c
@@ -2321,15 +2321,15 @@ int EvaluateEuler(PHEAD WORD *term, WORD level, WORD par)
 */
 			AT.WorkPointer += depth;
 			if ( first ) {
-				if ( *t == MZV ) CalculateMZV(aux4,indexes,depth);
-				else if ( *t == EULER ) CalculateEuler(aux4,indexes,depth);
-				else if ( *t == MZVHALF ) CalculateMZVhalf(aux4,indexes,depth);
+				if ( *t == MZV ) CalculateMZV(aux4,(int *)indexes,depth);
+				else if ( *t == EULER ) CalculateEuler(aux4,(int *)indexes,depth);
+				else if ( *t == MZVHALF ) CalculateMZVhalf(aux4,(int *)indexes,depth);
 				first = 0;
 			}
 			else {
-				if ( *t == MZV ) CalculateMZV(aux5,indexes,depth);
-				else if ( *t == EULER ) CalculateEuler(aux5,indexes,depth);
-				else if ( *t == MZVHALF ) CalculateMZVhalf(aux5,indexes,depth);
+				if ( *t == MZV ) CalculateMZV(aux5,(int *)indexes,depth);
+				else if ( *t == EULER ) CalculateEuler(aux5,(int *)indexes,depth);
+				else if ( *t == MZVHALF ) CalculateMZVhalf(aux5,(int *)indexes,depth);
 				mpf_mul(aux4,aux4,aux5);
 			}
 			*t = 0;

--- a/sources/reshuf.c
+++ b/sources/reshuf.c
@@ -2144,7 +2144,7 @@ WORD DoShuffle(WORD *term, WORD level, WORD fun, WORD option)
 	passed on.
 */
 	SHback = AN.SHvar;
-	SH->finishuf = &FinishShuffle;
+	SH->finishuf = (FINISHUFFLE) &FinishShuffle;
 	SH->do_uffle = &DoShuffle;
 	SH->outterm = AT.WorkPointer;
 	AT.WorkPointer += *term;
@@ -2638,7 +2638,7 @@ retry2:;
 	*AN.RepPoint = 1;
 
 	SHback = AN.SHvar;
-	SH->finishuf = &FinishStuffle;
+	SH->finishuf = (FINISHUFFLE) &FinishStuffle;
 	SH->do_uffle = &DoStuffle;
 	SH->outterm = AT.WorkPointer;
 	AT.WorkPointer += *term;
@@ -2737,9 +2737,9 @@ int Stuffle(WORD *from1, WORD *from2, WORD *to)
 */
 	SH->stop1 = SH->ststop1;
 	SH->stop2 = SH->ststop2;
-	SH->finishuf = &FinishShuffle;
+	SH->finishuf = (FINISHUFFLE) &FinishShuffle;
 	if ( Shuffle(from1,from2,to) ) goto stuffcall;
-	SH->finishuf = &FinishStuffle;
+	SH->finishuf = (FINISHUFFLE) &FinishStuffle;
 /*
 	Now we have to select a pair, one from 1 and one from 2.
 */


### PR DESCRIPTION
Hi,

When compiling form in Ubuntu some errors arose because since GCC-14 the implicit casting from all pointer types to all other pointer types is no longer allowed [1].

I got a successful build in all the archs, especially armhf which is more sensible to these cases.

Therefore, I'm forwarding these changes to you for your consideration. Thank you,

Miriam

[1] https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors