### PR TITLE
Fix termination when saving long-named expressions in a pre-proc loop

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -1910,6 +1910,18 @@ Save test.res abcdefghijklmnop;
 .end
 assert succeeded?
 *--#] Issue192_3 :
+*--#[ Issue192_4 :
+* Also related: Issue 334.
+Global abcdefghijklmnop1 = 17;
+Global abcdefghijklmnop2 = 17;
+.store
+#do i = 1,2
+    Save test.res abcdefghijklmnop`i';
+#enddo
+.end
+assert warning?("saved expr name over 16 char: abcdefghijklmnop1")
+assert warning?("saved expr name over 16 char: abcdefghijklmnop2")
+*--#] Issue192_4 :
 *--#[ Issue197 :
 * mul_ ignores denominator factors
 #if "{2^32}" == "0"

--- a/sources/store.c
+++ b/sources/store.c
@@ -423,7 +423,9 @@ int CoSave(UBYTE *inp)
 			if ( GetVar(inp,&type,&number,CEXPRESSION,NOAUTO) != NAMENOTFOUND ) {
 				if ( e[number].status == STOREDEXPRESSION ) {
 					if ( StrLen(AC.exprnames->namebuffer+e[number].name) > MAXENAME ) {
-						MesPrint("&Warning: saved expr name over %d char: %s", MAXENAME, AC.exprnames->namebuffer+e[number].name);
+						char msg[100];
+						snprintf(msg, sizeof(msg), "saved expr name over %d char: %s", MAXENAME, AC.exprnames->namebuffer+e[number].name);
+						Warning(msg);
 					}
 /*
 		Here we have to locate the stored expression, copy its index entry
@@ -525,7 +527,9 @@ NextExpr:;
 		/* Make sure there is at least one stored expression: */
 		if ( n > 0 ) { do {
 			if ( StrLen(AC.exprnames->namebuffer+e->name) > MAXENAME ) {
-				MesPrint("&Warning: saved expr name over %d char: %s", MAXENAME, AC.exprnames->namebuffer+e->name);
+				char msg[100];
+				snprintf(msg, sizeof(msg), "saved expr name over %d char: %s", MAXENAME, AC.exprnames->namebuffer+e->name);
+				Warning(msg);
 			}
 			if ( e->status == STOREDEXPRESSION ) exprInStorageFlag = 1;
 			e++;


### PR DESCRIPTION
It was not intended in #500 that this warning crashes form, which happened here when Save was called in a pre-processor loop. This is due to the leading & of the message which triggers the source file line information. Warning protects from the crash by temporarily setting the "iswarning" variable which causes MesPrint to then not terminate.

This can be easily cleaned up later if Warning is refactored to take a format string and variable arguments.

An alternative would be to move the `static int iswarning;` of `message.c` into one of the header files, but that seems equally as messy as this fix.