### PR TITLE
micro-optimization: input vector for poly::get_variables()

### DIFF
--- a/sources/poly.cc
+++ b/sources/poly.cc
@@ -36,6 +36,7 @@
 #include "poly.h"
 #include "polygcd.h"
 
+#include <cassert>
 #include <cctype>
 #include <cmath>
 #include <algorithm>
@@ -2386,7 +2387,8 @@ const poly poly::simple_poly (PHEAD int x, const poly &a, int b, int p, int n) {
 
 // gets all variables in the expressions and stores them in AN.poly_vars
 // (it is assumed that AN.poly_vars=NULL)
-void poly::get_variables (PHEAD vector<WORD *> es, bool with_arghead, bool sort_vars) {
+void poly::get_variables (PHEAD const vector<WORD *> &es, bool with_arghead, bool sort_vars) {
+	assert(AN.poly_vars == NULL);
 
 	AN.poly_num_vars = 0;
 
@@ -2396,7 +2398,7 @@ void poly::get_variables (PHEAD vector<WORD *> es, bool with_arghead, bool sort_
 	
 	// extract all variables
 	for (int ei=0; ei<(int)es.size(); ei++) {
-		WORD *e = es[ei];
+		const WORD *e = es[ei];
 
 		// fast notation
 		if (*e == -SNUMBER) {

--- a/sources/poly.h
+++ b/sources/poly.h
@@ -118,7 +118,7 @@ public:
 	static const poly simple_poly (PHEAD int, const poly&, int=1, int=0, int=1);
 
 	// conversion from/to form notation
-	static void get_variables (PHEAD std::vector<WORD *>, bool, bool);
+	static void get_variables (PHEAD const std::vector<WORD *> &, bool, bool);
 	static const poly argument_to_poly (PHEAD WORD *, bool, bool, poly *den=NULL);
 	static void poly_to_argument (const poly &, WORD *, bool);
 	static void poly_to_argument_with_den (const poly &, WORD, const UWORD *, WORD *, bool);

--- a/sources/polywrap.cc
+++ b/sources/polywrap.cc
@@ -146,6 +146,7 @@ WORD *poly_gcd(PHEAD WORD *a, WORD *b, WORD fit) {
 	
 	// Extract variables
 	vector<WORD *> e;
+	e.reserve(2);
 	e.push_back(a);
 	e.push_back(b);
 	poly::get_variables(BHEAD e, false, true);
@@ -202,6 +203,7 @@ WORD *poly_divmod(PHEAD WORD *a, WORD *b, int divmod, WORD fit) {
 
 	// get variables
 	vector<WORD *> e;
+	e.reserve(2);
 	e.push_back(a);
 	e.push_back(b);
 	poly::get_variables(BHEAD e, false, false);
@@ -617,6 +619,7 @@ WORD *poly_ratfun_add (PHEAD WORD *t1, WORD *t2) {
 	
 	// Extract variables
 	vector<WORD *> e;
+	e.reserve(4);
 	
 	for (WORD *t=t1+FUNHEAD; t<t1+t1[1];) {
 		e.push_back(t);
@@ -626,6 +629,8 @@ WORD *poly_ratfun_add (PHEAD WORD *t1, WORD *t2) {
 		e.push_back(t);
 		NEXTARG(t);
 	}
+
+	assert(e.size() == 4);
 
 	poly::get_variables(BHEAD e, true, true);
 	
@@ -1679,6 +1684,7 @@ WORD *poly_inverse(PHEAD WORD *arga, WORD *argb) {
 	
 	// Extract variables
 	vector<WORD *> e;
+	e.reserve(2);
 	e.push_back(arga);
 	e.push_back(argb);
 	poly::get_variables(BHEAD e, false, true);
@@ -1808,6 +1814,7 @@ WORD *poly_mul(PHEAD WORD *a, WORD *b) {
 
 	// Extract variables
 	vector<WORD *> e;
+	e.reserve(2);
 	e.push_back(a);
 	e.push_back(b);
 	poly::get_variables(BHEAD e, false, false);  // TODO: any performance effect by sort_vars=true?


### PR DESCRIPTION
`poly::get_variables()` does not need a temporary copy of the input vector containing pointers to function arguments. Passing it by reference rather than by value avoids a heap allocation and a memory copy.
