### PR TITLE
Run-time deprecation warning for native Windows, 32-bit systems, ParFORM and Checkpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  FORM_IGNORE_DEPRECATION: 1
+
 jobs:
   # Generate the tarball distribution, e.g., "form-v4.2.1.tar.gz" for v4.2.1.
   # The tarball will be tested in the following "build-bin" job.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  FORM_IGNORE_DEPRECATION: 1
+
 jobs:
   # Simple tests on Linux; except the ParFORM case, they probably pass unless
   # the committer has forgotten running "make check".

--- a/sources/checkpoint.c
+++ b/sources/checkpoint.c
@@ -840,6 +840,7 @@ static void print_M()
 	MesPrint("%d", AM.ggShortStatsMax);
 	MesPrint("--MARK 11");
 	MesPrint("%d", AM.FromStdin);
+	MesPrint("%d", AM.IgnoreDeprecation);
 	MesPrint("%%%% END M_const");
 /*	fflush(0); */
 }
@@ -1503,6 +1504,7 @@ int DoRecovery(int *moduletype)
 	R_COPY_S(AM.Path,UBYTE *);
 
 	R_SET(AM.FromStdin, BOOL);
+	R_SET(AM.IgnoreDeprecation, BOOL);
 
 #ifdef PRINTDEBUG
 	print_M();
@@ -2574,6 +2576,7 @@ static int DoSnapshot(int moduletype)
 	S_WRITE_S(AM.Path);
 
 	S_WRITE_B(&AM.FromStdin,sizeof(BOOL));
+	S_WRITE_B(&AM.IgnoreDeprecation,sizeof(BOOL));
 
 	/*#] AM :*/ 
 	/*#[ AC :*/

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -608,6 +608,7 @@ int CoOff(UBYTE *s)
 			AR.gzipCompress = 0;
 		}
 		else if ( StrICont(t,(UBYTE *)"checkpoint") == 0 ) {
+			PrintDeprecation("the checkpoint mechanism", "issues/626");
 			AC.CheckpointInterval = 0;
 			if ( AC.CheckpointRunBefore ) { free(AC.CheckpointRunBefore); AC.CheckpointRunBefore = NULL; }
 			if ( AC.CheckpointRunAfter ) { free(AC.CheckpointRunAfter); AC.CheckpointRunAfter = NULL; }
@@ -706,6 +707,7 @@ int CoOn(UBYTE *s)
 			}
 		}
 		else if ( StrICont(t,(UBYTE *)"checkpoint") == 0 ) {
+			PrintDeprecation("the checkpoint mechanism", "issues/626");
 			AC.CheckpointInterval = 0;
 			if ( AC.CheckpointRunBefore ) { free(AC.CheckpointRunBefore); AC.CheckpointRunBefore = NULL; }
 			if ( AC.CheckpointRunAfter ) { free(AC.CheckpointRunAfter); AC.CheckpointRunAfter = NULL; }

--- a/sources/declare.h
+++ b/sources/declare.h
@@ -672,6 +672,7 @@ extern WORD   Processor(VOID);
 extern WORD   Product(UWORD *,WORD *,WORD);
 extern VOID   PrtLong(UWORD *,WORD,UBYTE *);
 extern VOID   PrtTerms(VOID);
+extern void   PrintDeprecation(const char *,const char *);
 extern VOID   PrintRunningTime(VOID);
 extern LONG   GetRunningTime(VOID);
 extern WORD   PutBracket(PHEAD WORD *);

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -1600,11 +1600,12 @@ struct M_const {
     WORD    numpi;
     WORD    BracketFactors[8];
     BOOL    FromStdin;             /* read the input from STDIN */
+    BOOL    IgnoreDeprecation;     /* ignore deprecation warning */
 #ifdef WITHFLOAT
 #ifdef WITHPTHREADS
 	PADPOSITION(17,30,62,84,(sizeof(pthread_rwlock_t)+sizeof(pthread_mutex_t)*2)+1);
 #else
-	PADPOSITION(17,28,62,84,1);
+	PADPOSITION(17,28,62,84,2);
 #endif
 #else
 #ifdef WITHPTHREADS


### PR DESCRIPTION
This is an implementation of deprecation messages like those in  https://github.com/vermaseren/form/issues/475#issuecomment-2146949223 but **at runtime startup** rather than at build time, for Windows, 32bit builds and ParFORM.

End users may not build binaries themselves. 32-bit binaries and ParFORM are distributed by various [distributors](https://repology.org/project/form/versions). We can distribute native Windows binaries if https://github.com/vermaseren/form/pull/511 is merged and `Delete Windows binaries` in `deploy.yml` is removed. This patch will cause these end users to see annoying deprecation warnings.

The deprecation warning looks like, for example, for ParFORM:
```
DeprecationWarning: We are considering deprecating the MPI version (ParFORM).
If you would like support to continue, please leave a comment at:

    https://github.com/vermaseren/form/issues/xxxxx

Otherwise, it will be discontinued in the future.
To suppress this warning, use the --ignore-deprecation command line option or
set the environment variable FORM_IGNORE_DEPRECATION=1.
```

This warning can be suppressed by the (undocumented) `--ignore-deprecation` option or the environment variable `FORM_IGNORE_DEPRECATION=1`.

TODO: we need 3 separate issues for users to leave comments regarding the deprecation.