### PR TITLE
Enhance test suite

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,7 @@ like the GNU glibc.
 The threaded version of FORM needs a Posix compliant implementation of threads
 (pthreads). The parallel version ParFORM needs an MPI implementation.
 
-The automated test suite of FORM requires Ruby version >= 1.9 and the testing
+The automated test suite of FORM requires Ruby version >= 2.0 and the testing
 framework "test/unit". For the latter, you may need to install test-unit gem
 separately.
 
@@ -174,7 +174,7 @@ can be used.
 Testing
 =======
 
-If Ruby version >= 1.9 and "test/unit" are installed on your system, the
+If Ruby version >= 2.0 and "test/unit" are installed on your system, the
 configure script enables the automated test suite. Then you can run it by
 
     make check

--- a/check/.rubocop.yml
+++ b/check/.rubocop.yml
@@ -1,5 +1,9 @@
-# AllCops:
-#   TargetRubyVersion: 2.1
+AllCops:
+  TargetRubyVersion: 2.0
+
+# We learned to do multiplication before addition in school.
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: false
 
 # Allow several expressions on the same line.
 Style/Semicolon:
@@ -28,6 +32,9 @@ Style/WhileUntilModifier:
 # Negating conditions. Forcing them may leads to confusing constructs.
 
 Style/NegatedIf:
+  Enabled: false
+
+Style/NegatedIfElseCondition:
   Enabled: false
 
 Style/NegatedWhile:
@@ -81,13 +88,22 @@ Metrics/PerceivedComplexity:
 
 # For now.
 
+Style/ClassVars:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
 Style/FormatStringToken:
   EnforcedStyle: unannotated
 
-Style/PerlBackrefs:
+Style/GlobalVars:
   Enabled: false
 
-Style/SlicingWithRange:  # OK only for Ruby 2.6+
+Style/OpenStructUse:
+  Enabled: false
+
+Style/PerlBackrefs:
   Enabled: false
 
 Style/SpecialGlobalVars:
@@ -95,3 +111,228 @@ Style/SpecialGlobalVars:
 
 Style/StderrPuts:
   Enabled: false
+
+#####
+
+# Enable all other cops.
+
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
+  Enabled: true
+Gemspec/DevelopmentDependencies: # new in 1.44
+  Enabled: true
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: true
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: true
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: true
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: true
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Lint/DuplicateMatchPattern: # new in 1.50
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/EmptyBlock: # new in 1.1
+  Enabled: true
+Lint/EmptyClass: # new in 1.3
+  Enabled: true
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/LiteralAssignmentInCondition: # new in 1.58
+  Enabled: true
+Lint/MixedCaseRange: # new in 1.53
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: true
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: true
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: true
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: true
+Lint/RedundantRegexpQuantifiers: # new in 1.53
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/SymbolConversion: # new in 1.9
+  Enabled: true
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: true
+Lint/TripleQuotes: # new in 1.9
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Lint/UselessRescue: # new in 1.43
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+Metrics/CollectionLiteralLength: # new in 1.47
+  Enabled: true
+Naming/BlockForwarding: # new in 1.24
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Security/IoMethods: # new in 1.22
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: true
+Style/ArrayIntersect: # new in 1.40
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CollectionCompact: # new in 1.2
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/ComparableClamp: # new in 1.44
+  Enabled: true
+Style/ConcatArrayLiterals: # new in 1.41
+  Enabled: true
+Style/DataInheritance: # new in 1.49
+  Enabled: true
+Style/DirEmpty: # new in 1.48
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: true
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EndlessMethod: # new in 1.8
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/ExactRegexpMatch: # new in 1.51
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/FileEmpty: # new in 1.48
+  Enabled: true
+Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileWrite: # new in 1.24
+  Enabled: true
+Style/HashConversion: # new in 1.10
+  Enabled: true
+Style/HashExcept: # new in 1.7
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: true
+Style/InPatternThen: # new in 1.16
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/MapToHash: # new in 1.24
+  Enabled: true
+Style/MapToSet: # new in 1.42
+  Enabled: true
+Style/MinMaxComparison: # new in 1.42
+  Enabled: true
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/NilLambda: # new in 1.3
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/QuotedSymbols: # new in 1.16
+  Enabled: true
+Style/RedundantArgument: # new in 1.4
+  Enabled: true
+Style/RedundantArrayConstructor: # new in 1.52
+  Enabled: true
+Style/RedundantConstantBase: # new in 1.40
+  Enabled: true
+Style/RedundantCurrentDirectoryInPath: # new in 1.53
+  Enabled: true
+Style/RedundantDoubleSplatHashBraces: # new in 1.41
+  Enabled: true
+Style/RedundantEach: # new in 1.38
+  Enabled: true
+Style/RedundantFilterChain: # new in 1.52
+  Enabled: true
+Style/RedundantHeredocDelimiterQuotes: # new in 1.45
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/RedundantLineContinuation: # new in 1.49
+  Enabled: true
+Style/RedundantRegexpArgument: # new in 1.53
+  Enabled: true
+Style/RedundantRegexpConstructor: # new in 1.52
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SingleLineDoEndBlock: # new in 1.57
+  Enabled: true
+Style/StringChars: # new in 1.12
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true
+Style/SuperWithArgsParentheses: # new in 1.58
+  Enabled: true
+Style/SwapValues: # new in 1.1
+  Enabled: true
+Style/YAMLFileRead: # new in 1.53
+  Enabled: true

--- a/check/README.md
+++ b/check/README.md
@@ -1,87 +1,89 @@
-FORM Test Suite
-===============
+# FORM Test Suite
 
 This directory contains a collection of test cases that can be used for
 verifying the behaviour of FORM. It also has a script to run the test cases and
 check the results.
 
-Prerequisites
--------------
+## Prerequisites
 
 The test runner script is written in [Ruby](https://www.ruby-lang.org/)
-and requires Ruby 1.9 or later. The script uses the so-called `test/unit`
+and requires Ruby 2.0 or later. The script uses the so-called `test/unit`
 library. In some Linux distributions the library is installed together with
 Ruby, while some distributions may have the library as an optional package,
 or one may need to manually install
 [test-unit](http://test-unit.github.io/test-unit/en/) via the `gem` command.
-Currently, the script runs only on Unix-like systems.
 
-Usage
------
+## Usage
 
 ### From the build system
 
 To use the test suite from the automatic build system
 (see also the [INSTALL](../INSTALL) file),
-run
+run the following command:
 
-```
+```bash
 # in the root build directory
 make check
 ```
 
 which tests the executables (release versions) compiled by the build system.
 
-### Testing in the standalone mode
+### Testing in standalone mode
 
 Alternatively, one can run the test runner script directly:
 
-```
+```bash
 # in the "check" directory
 ./check.rb
 ```
 
-By default, it tests `form` found in $PATH.
-To check another executable, give the path as a command line option:
+By default, this tests `form` found in `$PATH`.
+To test another executable, specify its path as a command-line argument:
 
-```
+```bash
 ./check.rb /path/to/form
 ```
 
-One can specify a TFORM (or ParFORM) executable in this way.
+One can also specify a TFORM (or ParFORM) executable in this way.
 TFORM and ParFORM will be run with 4 CPUs (can be changed by the `--cpu N`
 option).
 
 By default, all test cases in all FORM files (`*.frm`) found in the `check`
 directory (not in subdirectories) are used. To select test cases or FORM files
-to be run, give their names as command line options, for example,
+to be run, specify their names as command-line arguments. For example:
 
-```
-./check.rb examples.frm
+```bash
 ./check.rb Issue8
+./check.rb 'divmod_*'
+./check.rb examples.frm
 ```
 
-For more advanced options, see the help message shown by the `--help` option.
+For more advanced options, refer to the help message using the `--help` option.
 
-Writing tests
--------------
+## Writing tests
 
 ### Where to add test cases?
 
-Currently, the standard test set (run by default) consists of 3 files:
+Currently, the standard test set (run by default) consists of 4 files:
 
-- `examples.frm`: Examples found in the manual.
+- `examples.frm`: Examples provided in the manual.
 - `features.frm`: Test cases for newly added features.
 - `fixes.frm`: Test cases for bug fixes.
+- `user.frm`: Test cases contributed by users.
 
 Each test case in these files should finish in a short time: the timeout is set
 to 10 seconds. Bigger tests that take more time are put in subdirectories
-(e.g., forcer) and should be specified by command-line options when the test
-suite is invoked.
+(e.g., `forcer`) and should be specified by command-line options when the test
+suite is invoked:
+
+```bash
+./check.rb -C forcer  # The Forcer library must be available in FORMPATH.
+```
 
 ### Structure of a test case
 
-A test case is given as a fold in a FORM file. A simple example is:
+A test case is given as a fold in a FORM file.
+The following is a simple example:
 
 ```
 *--#[ Test1 :
@@ -95,16 +97,22 @@ assert result("F") =~ expr("1 + 2*x + x^2")
 ```
 
 The fold name `Test1` gives the name of the test case, which should be unique.
-The part before `.end` is a normal FORM program. After `.end`, one can write
-a Ruby program to check the results. In this example, `assert` method (which is
-provided by some unit test class) is used for checking whether its argument is
-`true`. The first assertion checks `succeeded?`, which gives `true` if the FORM
-successfully finishes. The second assertion checks the printed result of the
-expression `F` by a regular expression matching (`=~`). In the left-hand side,
-`result("F")` returns the (lastly) printed output for the expression `F` as
-a string. In the right-hand side, `expr("...")` makes a regular expression with
-removing white spaces in its argument. Since `expr()` removes all white spaces,
-one can also put new lines, for example,
+The part before `.end` is a normal FORM program.
+After `.end`, one can write a Ruby program to check the results.
+
+The `assert` method checks whether its argument evaluates to `true`.
+In this example:
+- The first assertion verifies `succeeded?`, which returns `true` if the FORM finishes successfully.
+- The second assertion checks the printed result of the
+expression `F` by a regular expression matching (`=~`).
+  - On the left-hand side, `result("F")` returns the (lastly) printed output
+    for the expression `F` as a string.
+  - On the right-hand side, `expr("...")` creates a regular expression
+    by removing white spaces in its argument.
+
+Since `expr()` removes all white spaces,
+one can include new lines in the argument.
+For example:
 
 ```
 *--#[ Test2 :
@@ -123,13 +131,171 @@ assert result("F") =~ expr("
 
 which is convenient to copy and paste a long output from a terminal.
 
-### Tips
+Two or more FORM programs, separated by `.end`, can be put in a test case.
+The part after the last `.end` is considered as a Ruby program.
+For example:
+```
+*--#[ Test3 :
+S x;
+G F = (1+x)^2;
+P;
+.store
+Save out.sav;
+.end
+Load out.sav;
+L G = F;
+P;
+.end
+assert succeeded?
+assert result("F") =~ expr("1 + 2*x + x^2")
+assert result("G") =~ expr("1 + 2*x + x^2")
+*--#] Test3 : 
+```
 
-- To verify that FORM finishes with a certain error, one can use
-  `assert compile_error?` or `assert runtime_error?`.
-- Two or more FORM programs, separated by `.end`, can be put in a test case.
-  Then the part after the last `.end` is for Ruby.
-- To skip a test case for some condition, one can specify it by `#pend_if`.
-  (See the result of grepping `pend_if` in the existing files.)
-- When a test case requires other text files, one can use `#prepare write`.
-  (See the result of grepping `prepare` in the existing files.)
+Some test cases need to run only under specific conditions.
+In such cases, one can use special instructions starting with `#`.
+For example:
+```
+*--#[ Test4 :
+S x;
+L F =
+#pipe echo "(1+x)^2"
+;
+P;
+.end
+#require unix?
+assert succeeded?
+assert result("F") =~ expr("1 + 2*x + x^2")
+*--#] Test4 : 
+```
+In this example, `#require unix?` ensures that the test runs
+only on Unix, where `#pipe` is expected to work.
+
+### Available methods
+
+#### Execution configuration
+
+- `timeout → integer or float`  
+  Timeout duration in seconds.
+- `ncpu → integer`  
+  Number of assigned CPUs.
+- `total_memory → integer`  
+  Total physical memory available in bytes.
+- `serial? → bool`  
+  `true` if FORM is the serial version, otherwise `false`.
+- `threaded? → bool`  
+  `true` if FORM is the multithreaded version (TFORM), otherwise `false`.
+- `mpi? → bool`  
+  `true` if FORM is the MPI version (ParFORM), otherwise `false`.
+- `valgrind? → bool`  
+  `true` if FORM is running under Valgrind, otherwise `false`.
+- `wordsize → integer`  
+  Word size in bytes used by FORM (`4` on 64-bit systems).
+- `cygwin? → bool`  
+  `true` if running on Cygwin, otherwise `false`.
+- `mac? → bool`  
+  `true` if running on macOS, otherwise `false`.
+- `linux? → bool`  
+  `true` if running on Linux, otherwise `false`.
+- `unix? → bool`  
+  `true` if running on Unix, otherwise `false`.
+- `windows? → bool`  
+  `true` if running on Windows, otherwise `false`.
+- `travis? → bool`  
+  `true` if running on Travis CI, otherwise `false`.
+- `github? → bool`  
+  `true` if running on GitHub Actions, otherwise `false`.
+
+#### Job status
+
+- `return_value → integer`  
+  Exit status of the FORM job.
+- `finished? → bool`  
+  `true` if the FORM job finished within the timeout, otherwise `false`.
+- `succeeded? → bool`  
+  `true` if the FORM job finished without any problems, otherwise `false`.
+- `warning? → bool`  
+  `true` if the FORM job issued a warning, otherwise `false`.
+- `warning?(expected_message : string) → bool`  
+  `true` if the FORM job issued the expected warning, otherwise `false`.
+
+The following methods are similar to `warning?`,
+but they check for preprocessor errors, compile-time errors,
+and run-time errors, respectively:
+
+- `preprocess_error? → bool`  
+  `preprocess_error?(expected_message : string) → bool`
+- `compile_error? → bool`  
+  `compile_error?(expected_message : string) → bool`
+- `runtime_error? → bool`  
+  `runtime_error?(expected_message : string) → bool`
+
+#### Standard streams
+
+- `stdout → string`  
+  Standard output of the FORM job.
+- `stderr → string`  
+  Standard error of the FORM job.
+
+#### Expressions
+
+The following methods assume the default format for printing expressions:
+
+- `result(expr_name : string) → string`  
+  The last printed output of the specified expression.
+- `result(expr_name : string, index : integer) → string`  
+  The printed output of the specified expression at the given index (zero-based).
+- `exact_result(expr_name : string) → string`  
+  `exact_result(expr_name : string, index : integer) → string`  
+  Similar to `result`, but returns the exact output, preserving line breaks and whitespaces.
+
+The following methods assume the default format for statistics:
+
+- `nterms(expr_name : string) → integer`  
+  `nterms(expr_name : string, index : integer) → integer`  
+  The number of terms as reported in the statistics for the specified expression.
+- `bytesize(expr_name : string) → integer`  
+  `bytesize(expr_name : string, index : integer) → integer`  
+  The size in bytes as reported in the statistics for the specified expression.
+
+#### Helper methods
+
+- `exact_pattern(str : string) → regexp`  
+  Regular expression constructed from the given text with escaping any special characters.
+- `pattern(str : string) → regexp`  
+  Similar to `exact_pattern`, but ignores whitespaces.
+- `expr(str : string) → regexp`  
+  Similar to `pattern`, but matches only with the whole expression.
+- `file(filename : string) → string`  
+  `read(filename : string) → string`  
+  Text in the specified file.
+- `write(filename : string, text : string) → nil`  
+  Writes a text into the specified file.
+
+### Available instructions
+
+- `#require <condition>`  
+  Ensures that the test is executed only if the specified `<condition>` is met.
+- `#pend_if <condition>`  
+  Marks the test as pending if the specified `<condition>` is met.
+- `#prepare <statement>`  
+  Executes the given `<statement>` before running the test.
+  For example:
+  ```
+  #prepare write "foo.prc", "#procedure foo\n#message foo\n#endprocedure"
+  ```
+- `#ulimit <limits>`  
+  Sets the resource limits. This is done via the `ulimit` command.
+  For example:
+  ```
+  #require linux?
+  #ulimit -v 8_000_000
+  ```
+  This sets the maximum amount of virtual memory available to
+  8,000,000 KiB (~ 8GB).
+- `#time_dilation <dilation>`  
+  Multiplies the timeout by the specified `<dilation>` factor.
+  For example:
+  ```
+  #time_dilation 2.0
+  ```

--- a/check/check.rb
+++ b/check/check.rb
@@ -8,8 +8,8 @@ exec ruby "-S" "-x" "$0" "$@"
 # rubocop:enable all
 
 # Check the Ruby version.
-if RUBY_VERSION < "1.9.0"
-  warn("ruby 1.9 required for the test suite")
+if RUBY_VERSION < "2.0.0"
+  warn("ruby 2.0 required for the test suite")
   exit(1)
 end
 

--- a/check/check.rb
+++ b/check/check.rb
@@ -691,9 +691,9 @@ module FormTest
   # true if the FORM job put warning messages.
   def warning?(expected_message = nil)
     if expected_message.nil?
-      @stdout =~ /(^|\R)\S+ Line \d+ --> Warning/
+      @stdout.include?("Warning:")
     else
-      @cleaned_stdout =~ Regexp.new("(^|\\R)\\S+ Line \\d+ --> Warning: .*#{Regexp.escape(expected_message)}")
+      @cleaned_stdout =~ Regexp.new("Warning: .*#{Regexp.escape(expected_message)}")
     end
   end
 

--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -998,10 +998,9 @@ assert result("test") =~ expr("0")
 *--#] Issue95 : 
 *--#[ Issue95b :
 #-
-#:filepatches        4
-#:largesize      25600
+#:filepatches       16
+#:largepatches      20
 #:maxtermsize      200
-#:smallsize      12800
 #:termsinsmall      16
 
 Off stats;
@@ -3134,7 +3133,7 @@ assert succeeded?
 assert result("test") =~ expr("0")
 *--#] Issue544 :
 *--#[ Issue563 :
-#: SubTermsInSmall 50
+#: SubTermsInSmall 64
 
 CFunction f,g;
 Symbol a;

--- a/configure.ac
+++ b/configure.ac
@@ -1000,13 +1000,13 @@ AM_CONDITIONAL(CONFIG_MAKEINDEX, [test "x$MAKEINDEX" != x])
 AM_CONDITIONAL(CONFIG_HTLATEX, [test "x$HTLATEX" != x])
 AM_CONDITIONAL(CONFIG_LATEX2HTML, [test "x$LATEX2HTML" != x])
 
-# Check for Ruby >= 1.9 and test/unit.
+# Check for Ruby >= 2.0 and test/unit.
 AC_PATH_PROG(RUBY, ruby, "")
 ok=yes
 test "x$RUBY" = x && ok=no
 if test "x$ok" = xyes; then
-	AC_MSG_CHECKING([whether ruby >= 1.9])
-	$RUBY -e 'exit(1) if RUBY_VERSION < "1.9.0"' >/dev/null 2>&1 || ok=no
+	AC_MSG_CHECKING([whether ruby >= 2.0])
+	$RUBY -e 'exit(1) if RUBY_VERSION < "2.0.0"' >/dev/null 2>&1 || ok=no
 	AC_MSG_RESULT([$ok])
 fi
 if test "x$ok" = xyes; then


### PR DESCRIPTION
This PR depends on the first commit in #511, which improves the portability of the test suite script.

It resolves #580 by updating the Ruby minimum version to 2.0.0. It also improves `--stat` option (order of) output, word size detection for v5.0.0, and includes code refactoring.

Hopefully, later I would like to add some resolution for #581 (warning detection) and update the usage in the README file of the test suite (`check/README.md`), but this PR could be merged as-is.