### PR TITLE
Better warnings for resized sub-buffers in DEBUGGING mode

### DIFF
--- a/sources/declare.h
+++ b/sources/declare.h
@@ -876,7 +876,7 @@ extern int    ToFast(WORD *,WORD *);
 extern SETUPPARAMETERS *GetSetupPar(UBYTE *);
 extern int    RecalcSetups(VOID);
 extern int    AllocSetups(VOID);
-extern SORTING *AllocSort(LONG,LONG,LONG,LONG,int,int,LONG);
+extern SORTING *AllocSort(LONG,LONG,LONG,LONG,int,int,LONG,int);
 extern VOID   AllocSortFileName(SORTING *);
 extern UBYTE *LoadInputFile(UBYTE *,int);
 extern UBYTE  GetInput(VOID);

--- a/sources/setfile.c
+++ b/sources/setfile.c
@@ -573,7 +573,7 @@ int AllocSetups(VOID)
 #endif
 	AM.S0 = 0;
 	AM.S0 = AllocSort(LargeSize,SmallSize,SmallEsize,TermsInSmall
-					,MaxPatches,MaxFpatches,IOsize);
+					,MaxPatches,MaxFpatches,IOsize,0);
 	/* AM.S0->file.ziosize was already set to a (larger) value by AllocSort, here it is re-set. */
 #ifdef WITHZLIB
 	AM.S0->file.ziosize = IOsize;
@@ -848,9 +848,12 @@ VOID WriteSetup(VOID)
 		Routine allocates a complete struct for sorting.
 		To be used for the main allocation of the sort buffers, and
 		in a later stage for the function and subroutine sort buffers.
+		The level arg denotes a main buffer allocation (0) or a sub-buffer
+		allocation (1), used only for printing warning messages for buffer
+		size adjustments in DEBUGGING mode.
 */
 SORTING *AllocSort(LONG inLargeSize, LONG inSmallSize, LONG inSmallEsize, LONG inTermsInSmall,
-                   int inMaxPatches, int inMaxFpatches, LONG inIOsize)
+                   int inMaxPatches, int inMaxFpatches, LONG inIOsize, int level)
 {
 	LONG LargeSize = inLargeSize;
 	LONG SmallSize = inSmallSize;
@@ -911,10 +914,13 @@ SORTING *AllocSort(LONG inLargeSize, LONG inSmallSize, LONG inSmallEsize, LONG i
 	}
 
 #if DEBUGGING
-	if ( LargeSize != inLargeSize ) { MesPrint("Warning: LargeSize adjusted: %l -> %l", inLargeSize, LargeSize); }
-	if ( SmallSize != inSmallSize ) { MesPrint("Warning: SmallSize adjusted: %l -> %l", inSmallSize, SmallSize); }
-	if ( SmallEsize != inSmallEsize ) {MesPrint("Warning: SmallEsize adjusted: %l -> %l", inSmallEsize, SmallEsize); }
-	if ( TermsInSmall != inTermsInSmall ) { MesPrint("Warning: TermsInSmall adjusted: %l -> %l", inTermsInSmall, TermsInSmall); }
+	char *prefix;
+	if ( level == 0 ) { prefix = ""; }
+	else { prefix = "Sub"; }
+	if ( LargeSize != inLargeSize ) { MesPrint("Warning: %sLargeSize adjusted: %l -> %l", prefix, inLargeSize, LargeSize); }
+	if ( SmallSize != inSmallSize ) { MesPrint("Warning: %sSmallSize adjusted: %l -> %l", prefix, inSmallSize, SmallSize); }
+	if ( SmallEsize != inSmallEsize ) {MesPrint("Warning: %sSmallEsize adjusted: %l -> %l", prefix, inSmallEsize, SmallEsize); }
+	if ( TermsInSmall != inTermsInSmall ) { MesPrint("Warning: %sTermsInSmall adjusted: %l -> %l", prefix, inTermsInSmall, TermsInSmall); }
 	if ( MaxPatches != inMaxPatches ) { MesPrint("Warning: MaxPatches adjusted: %d -> %d", inMaxPatches, MaxPatches); }
 	if ( MaxFpatches != inMaxFpatches ) {MesPrint("Warning: MaxFPatches adjusted: %d -> %d", inMaxFpatches, MaxFpatches); }
 	/* This one is always changed if the LargeSize has not been... */

--- a/sources/sort.c
+++ b/sources/sort.c
@@ -646,7 +646,7 @@ WORD NewSort(PHEAD0)
 		if ( AN.FunSorts[AR.sLevel] == 0 ) {
 			AN.FunSorts[AR.sLevel] = AllocSort(
 				AM.SLargeSize,AM.SSmallSize,AM.SSmallEsize,AM.STermsInSmall
-					,AM.SMaxPatches,AM.SMaxFpatches,AM.SIOsize);
+					,AM.SMaxPatches,AM.SMaxFpatches,AM.SIOsize,1);
 		}
 		AN.FunSorts[AR.sLevel]->PolyFlag = 0;
 	}

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -737,7 +737,8 @@ ALLPRIVATES *InitializeOneThread(int identity)
 						 ,AM.S0->MaxPatches
 /*						 ,AM.S0->MaxPatches/numberofworkers  */
 						 ,AM.S0->MaxFpatches/numberofworkers
-						 ,AM.S0->file.POsize);
+						 ,AM.S0->file.POsize
+						 ,0);
 	}
 	AR.CompressPointer = AR.CompressBuffer;
 /*


### PR DESCRIPTION
Add a function argument to AllocSort to specify which buffers are being allocated. This makes it straightforward to print an appropriate warning message.