### PR TITLE
Write term size in compress buffer in GetOneTerm when reading from fi…

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2016,6 +2016,34 @@ else
 end
 assert result("Zero") =~ expr("0")
 *--#] Issue197 : 
+*--#[ Issue214 :
+#-
+#: MaxTermSize 500
+#: ScratchSize 1K
+#: SortIOSize 1K
+
+Off compress;
+Symbol x,y,z,i;
+CFunction f;
+
+Local test = sum_(i,1,100,f(i*(x+y))*(x+y)^20) - 52824783675150;
+Bracket f;
+.sort
+Keep Brackets;
+
+Identify f(x?) = x;
+.sort
+
+Identify x = 1;
+Identify y = 2;
+
+Print +s;
+.end
+# This is not valgrind clean under parform
+#pend_if valgrind? && mpi?
+assert succeeded?
+assert result("test") =~ expr("0")
+*--#] Issue214 :
 *--#[ Issue219 :
 * Corrupted characters in {-9223372036854775808}
 #$n32  = -2^31;

--- a/sources/store.c
+++ b/sources/store.c
@@ -1313,7 +1313,7 @@ WORD GetOneTerm(PHEAD WORD *term, FILEHANDLE *fi, POSITION *pos, int par)
 				goto ErrGet;
 			}
 			r++;
-			if ( i < 0 ) {
+			if ( i < 0 ) { /* Loading a compressed term */
 				*p = -i + 1;
 				while ( ++i <= 0 ) *term++ = *r++;
 				if ( par == 0 ) {
@@ -1337,10 +1337,11 @@ WORD GetOneTerm(PHEAD WORD *term, FILEHANDLE *fi, POSITION *pos, int par)
 					error = 3;
 					goto ErrGet;
 				}
-				*rr = *p;
+				*rr = *p; /* Write the proper term size to *AR.CompressPointer */
 			}
-			else {
+			else { /* Loading a regular term */
 				if ( !j ) return(0);
+				*rr = i; /* Write the proper term size to *AR.CompressPointer */
 				j--;
 			}
 			i = (WORD)j;


### PR DESCRIPTION
…le and off compress

In the case if "Off Compress;" the term size was not written into the compress buffer when reading from a file, and term compression is off.

This results in terms which are incomplete or have extra junk on the end going through Generator; the rest is chaos.

Fixes #214 