### PR TITLE
Fix rare FindrNumber/TermRenumber crashes when loading saves

### DIFF
--- a/sources/setfile.c
+++ b/sources/setfile.c
@@ -729,6 +729,8 @@ int AllocSetups(VOID)
 	AM.NumStoreCaches = sp->value;
 	sp = GetSetupPar((UBYTE *)"sizestorecache");
 	AM.SizeStoreCache = sp->value;
+	/* Make sure this is a multiple of sizeof(WORD). */
+	AM.SizeStoreCache = ((AM.SizeStoreCache+sizeof(WORD)-1)/sizeof(WORD))*sizeof(WORD);
 #ifndef WITHPTHREADS
 /*
 	Install the store caches (15-aug-2006 JV)

--- a/sources/store.c
+++ b/sources/store.c
@@ -1695,7 +1695,9 @@ InNew:
 					num = *from++;
 					ADDPOS(*position,sizeof(WORD));
 					*to += (WORD)num;
-/*					first = 0; */
+					/* This next line has always been commented, but uncommenting it
+					   fixes a rare bug when loading certain save files. */
+					first = 0;
 					*InCompState = (WORD)(num + 2);
 				}
 				goto PastCon;


### PR DESCRIPTION
Uncommenting this line fixes crashes when loading certain save files, where the sizes of the terms have some interaction with SizeStoreCache.

Changing that value or setting NumStoreCaches to 0 is a works-around also.

Closes #420 and #484