### PR TITLE
Fix bugs due to empty set in wildcard restriction and + signs

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -3313,6 +3313,39 @@ Local test3 = 3;
 #pend_if mpi?
 assert runtime_error?("isnumerical: expression is not yet defined!")
 *--#] Issue577_2 :
+*--#[ Issue599 :
+#-
+On names;
+Off statistics;
+CFunction A1,...,A6;
+Symbol j,x,z,y;
+
+Local ff =
+	+ A1(1) + A2(2) + A3(3)
+		+ A4(1) + A5(2) + A6(3)
+		;
+
+Identify A1(j?{1,2,3}[x]) = A1({ 10, 20, 30}[x]);
+Identify A2(j?{1,2,3}[x]) = A2({+10,+20,+30}[x]);
+Identify A3(j?{1,2,3}[x]) = A3({-10,-20,-30}[x]);
+Identify A4(j?{1,2,3}[x]) = A4({+-10,--20,-+30}[x]);
+Identify A5(j?{1,2,3}[x]) = A5({--10,-+20,+-30}[x]);
+Identify A6(j?{1,2,3}[x]) = A6({-+10,+-20,--30}[x]);
+
+Print;
+.end
+assert succeeded?
+assert result("ff") =~ expr("A1(10) + A2(20) + A3(-30) + A4(-10) + A5(-20) + A6(30)")
+assert stdout =~ exact_pattern(<<'EOF')
+ Sets
+   {}: 1 2 3
+   {}: 10 20 30
+   {}: -10 -20 -30
+   {}: -10 20 -30
+   {}: 10 -20 -30
+   {}: -10 -20 30
+EOF
+*--#] Issue599 : 
 *--#[ PullReq535 :
 * This test requires more than the specified 50K workspace.
 #:maxtermsize 200

--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -3133,6 +3133,59 @@ Print +s;
 assert succeeded?
 assert result("test") =~ expr("0")
 *--#] Issue544 :
+*--#[ Issue554_1 :
+CF f;
+S x;
+L F = f(x);
+id f(x?{}) = x;
+print;
+.end
+assert succeeded?
+assert result("F") =~ expr("f(x)")
+*--#] Issue554_1 :
+*--#[ Issue554_2 :
+CF f;
+S x;
+L F = f(x);
+id f(x?!{}) = x;
+print;
+.end
+assert succeeded?
+assert result("F") =~ expr("f(x)")
+*--#] Issue554_2 :
+*--#[ Issue554_3 :
+CF f;
+S x;
+Set empty: ;
+L F = f(x);
+id f(x?empty) = x;
+print;
+.end
+assert succeeded?
+assert result("F") =~ expr("f(x)")
+*--#] Issue554_3 :
+*--#[ Issue554_4 :
+CF f;
+S x;
+Set empty: ;
+L F = f(x);
+id f(x?!empty) = x;
+print;
+.end
+assert succeeded?
+assert result("F") =~ expr("f(x)")
+*--#] Issue554_4 :
+*--#[ Issue554_5 :
+CF f;
+S x,y;
+L F = f(1)+f(2)+f(3);
+id f(x?{}) = x;
+id f(y?{1,2}) = x^y;
+print;
+.end
+assert succeeded?
+assert result("F") =~ expr("x + x^2 + f(3)")
+*--#] Issue554_5 :
 *--#[ Issue563 :
 #: SubTermsInSmall 50
 

--- a/sources/names.c
+++ b/sources/names.c
@@ -2160,7 +2160,10 @@ int DoElements(UBYTE *s, SETS set, UBYTE *name)
 	while ( *s ) {
 		if ( *s == ',' ) { s++; continue; }
 		sgn = 0;
-		while ( *s == '-' || *s == '+' ) { sgn ^= 1; s++; }
+		while ( *s == '-' || *s == '+' ) {
+			if ( *s == '-' ) sgn ^= 1;
+			s++;
+		}
 		cname = s;
 		if ( FG.cTable[*s] == 0 || *s == '_' || *s == '[' ) {
 			if ( ( s = SkipAName(s) ) == 0 ) {

--- a/sources/wildcard.c
+++ b/sources/wildcard.c
@@ -2257,6 +2257,15 @@ NoMnot:
 */
 		w = SetElements + Sets[j].first;
 		m = SetElements + Sets[j].last;
+		if ( w == m ) {
+/*
+			The set is empty! In principle this could be a syntax error, but
+			let's choose to just not match. Using `goto NoMnot` would mean
+			that, e.g. `id f(x?!{}) = x;` would match.
+*/
+			goto NoMatch;
+		}
+
 		if ( ( Sets[j].flags & ORDEREDSET ) == ORDEREDSET ) {
 /*
 			We search first and ask questions later


### PR DESCRIPTION
This PR fixes #554 and #599 .

The behaviour that I noted at the end of https://github.com/vermaseren/form/issues/554#issuecomment-2461742781 is intended. When creating the {} sets, it finds that they exist already and doesn't create a copy:
https://github.com/vermaseren/form/blob/8abec49f876deae1d13ad159519b301f0b140dc5/sources/names.c#L2471-L2474

Thus the following defines only xs and xs2:
```
#-
off stats;
On names;
CF f;
S x,y;
set xs: ;
set xs2: 1,2;
L F = f(1)+f(2)+f(3);
id f(x?{}) = x;
id f(y?{1,2}) = x^y;
print;
.end
```

There is one point for discussion: the second commit implies that `id f(x?!{}) = x;` also does not match. In principle one could claim that x is indeed not a member of the empty set, so that this should match, but to my knowledge there will never be a case where `x?` does match an empty set (`x?` can not be "nothing" in FORM currently) so it feels a bit odd to match in this case to me.

One could even claim that `x?{}` could be a syntax error and terminate. In that case the `x?!{}` question is irrelevant.

Any thoughts?