### PR TITLE
Restrict code coverage to tests checked with Valgrind

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,7 +230,7 @@ jobs:
         run: make -C sources -j 4 ${{ matrix.bin }}
 
       - name: Test
-        run: ./check/check.rb ./sources/${{ matrix.bin }} --stat --timeout 30 ${{ matrix.nthreads && format('-w{0}', matrix.nthreads) || '' }}
+        run: ./check/check.rb ./sources/${{ matrix.bin }} --stat --timeout 30 ${{ matrix.nthreads && format('-w{0}', matrix.nthreads) || '' }} --fake-valgrind
 
       - name: Generate LCOV coverage data
         run: |


### PR DESCRIPTION
This patch restricts code coverage to tests checked with Valgrind by using the new `--fake-valgrind` option.
See also discussion in #524.