### PR TITLE
docs: update InParallel documentation with ParFORM considerations

### DIFF
--- a/doc/manual/setup.tex
+++ b/doc/manual/setup.tex
@@ -286,7 +286,7 @@ thread (\ref{parallel}).}
 
 \leftvitem{4.0cm}{ThreadScratchOutSize\index{setup!threadscratchoutsize}\index{threadscratchoutsize}}
 \rightvitem{12.6cm}{The size of the output scratch buffers for each of the 
-worker threads. These buffers will be used when the InParallel 
+worker threads. These buffers will be used by \TFORM{} when the InParallel 
 statement~\ref{substainparallel} is active. They are used to catch the 
 output of the expressions as processed by the individual workers before 
 they are copied to the output scratch buffer/file of the master. The output 

--- a/doc/manual/statements.tex
+++ b/doc/manual/statements.tex
@@ -2743,7 +2743,7 @@ Syntax & inparallel; \\
 \end{tabular} \vspace{4mm}
 
 \noindent This statement is only active in the context of 
-\TFORM\index{TFORM}. It causes 
+\TFORM\index{TFORM} and \ParFORM\index{ParFORM}. It causes 
 (small) expressions to be executed side by side. Normally the terms of 
 expressions are distributed over the processors and the expressions are 
 executed one by one. This isn't very efficient for small expressions 
@@ -3515,7 +3515,7 @@ Syntax & notinparallel; \\
 \end{tabular} \vspace{4mm}
 
 \noindent This statement is only active in the context of 
-\TFORM\index{TFORM}. It vetoes (small) expressions to be executed side by 
+\TFORM\index{TFORM} and \ParFORM\index{ParFORM}. It vetoes (small) expressions to be executed side by 
 side. For a complete explanation of this type of running one should look at 
 the InParallel~\ref{substainparallel} statement. Because the default is 
 that expressions are executed one by one, the major use of this statement 


### PR DESCRIPTION
It seems that the documentation of `InParallel` was written before ParFORM was merged into the code base.