### PR TITLE
fix: check function symmetry properties after ChainIn

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -116,6 +116,26 @@ P;
 assert succeeded?
 assert result("F") =~ expr("f1(1)+f2(0)+f3(3)")
 *--#] Forum3t187 : 
+*--#[ Discussion639 :
+#-
+Off stats;
+
+CFunction eps(antisymmetric);
+Vector p1,p2,p3;
+
+Local zero = eps(p1,p2,p3,p1+p2);
+
+ChainOut eps;
+SplitArg eps;
+Repeat Identify eps(p1?,p2?) = eps(p1)+eps(p2);
+ChainIn eps;
+* the result should be zero without a sort here
+
+Print;
+.end
+assert succeeded?
+assert result("zero") =~ expr("0")
+*--#] Discussion639 :
 *--#[ Issue7_1 :
 * SegFault when #optimizing trivial bracket
 Symbol x;

--- a/sources/function.c
+++ b/sources/function.c
@@ -692,7 +692,7 @@ int ChainIn(PHEAD WORD *term, WORD funnum)
 {
 	GETBIDENTITY
 	WORD *t, *tend, *m, *tt, *ts;
-	int action;
+	int action, normFlag = 0;
 	if ( funnum < 0 ) {	/* Dollar to be expanded */
 		funnum = DolToFunction(BHEAD -funnum);
 		if ( AN.ErrorInDollar || funnum <= 0 ) {
@@ -714,6 +714,7 @@ int ChainIn(PHEAD WORD *term, WORD funnum)
 			tt = t;
 			if ( t >= tend || *t != funnum ) continue;
 			action = 1;
+			normFlag = 1;
 			while ( t < tend && *t == funnum ) {
 				ts = t + t[1];
 				t += FUNHEAD;
@@ -726,6 +727,14 @@ int ChainIn(PHEAD WORD *term, WORD funnum)
 			break;
 		}
 	} while ( action );
+
+	if ( normFlag ) {
+		/* We need to check the newly-constructed arguments w.r.t symmetry properties */
+		MarkDirty(term, DIRTYSYMFLAG);
+		AT.WorkPointer = term + *term;
+		Normalize(BHEAD term);
+	}
+
 	return(0);
 }
 

--- a/sources/proces.c
+++ b/sources/proces.c
@@ -3841,6 +3841,8 @@ CommonEnd:
 					AT.WorkPointer = term + *term;
 					if ( ChainIn(BHEAD term,C->lhs[level][2]) ) goto GenCall;
 					AT.WorkPointer = term + *term;
+					/* Symmetry properties might mean the term has vanished */
+					if ( *term == 0 ) goto Return0;
 					if ( *term != lter ) *AN.RepPoint = 1;
 					}
 					break;


### PR DESCRIPTION
The result of a ChainIn might vanish due to a repeated argument in an antisymmetric function, for eg. Normalize the output of ChainIn to check this.

I had to experiment a bit to work out some valgrind errors: these were related to needing to jump to Return0 in Generator if the term disappears.

Resolves #639 