### PR TITLE
Fix IntoHide, add NIntoHide

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -196,8 +196,10 @@ assert result("expr") =~ expr("1")
 *--#[ Issue10 :
 #-
 Local test1 = 1;
+Local test2 = 1;
 .sort
 IntoHide;
+NIntoHide test2;
 * test1 should be multiplied here
 Multiply 2;
 .sort
@@ -209,6 +211,7 @@ Print;
 .end
 assert succeeded?
 assert result("test1") =~ expr("2");
+assert result("test2") =~ expr("4");
 *--#] Issue10 :
 *--#[ Issue21 :
 * Occurs() with two or more terms in function arguments may get freeze

--- a/doc/manual/statements.tex
+++ b/doc/manual/statements.tex
@@ -3459,6 +3459,35 @@ Here all active expressions will be transferred to the hide file except for
 the expressions \verb:F1: and \verb:F2:. \vspace{10mm}
 
 %--#] nhide : 
+%--#[ nintohide :
+
+\section{nintohide}
+\label{substanintohide}
+
+\noindent \begin{tabular}{ll}
+Type & Specification statement\\
+Syntax & nintohide; \\
+       & nintohide {\tt<}list of expressions{\tt>};
+\\ See also & hide (\ref{substahide}),
+              unhide (\ref{substaunhide}),
+              nunhide (\ref{substanunhide}),
+              pushhide (\ref{substapushhide}),
+              pophide (\ref{substapophide}),
+              intohide (\ref{substaintohide})
+\end{tabular} \vspace{4mm}
+
+\noindent In its first variety\index{nintohide} this statement undoes all
+intohide\index{intohide} plans that exist thus far in the current module. In the
+second variety it does this only for the specified active\index{active}
+expressions. See the intohide statement in \ref{substaintohide}. Example:
+\begin{verbatim}
+   Intohide;
+   Nintohide F1,F2;
+\end{verbatim}
+Here all active expressions will be transferred to the hide file at the end of the
+current module, except for the expressions \verb:F1: and \verb:F2:. \vspace{10mm}
+
+%--#] nhide : 
 %--#[ normalize :
 
 \section{normalize}

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -1357,134 +1357,143 @@ int SetExprCases(int par, int setunset, int val)
 	switch ( par ) {
 		case SKIP:
 			switch ( val ) {
-		        case SKIPLEXPRESSION:
+				case SKIPLEXPRESSION:
 					if ( !setunset ) val = LOCALEXPRESSION;
-		            break;
-		        case SKIPGEXPRESSION:
+					break;
+				case SKIPGEXPRESSION:
 					if ( !setunset ) val = GLOBALEXPRESSION;
-		            break;
-		        case LOCALEXPRESSION:
+					break;
+				case LOCALEXPRESSION:
 					if ( setunset ) val = SKIPLEXPRESSION;
-		            break;
-		        case GLOBALEXPRESSION:
+					break;
+				case GLOBALEXPRESSION:
 					if ( setunset ) val = SKIPGEXPRESSION;
-		            break;
-		        case INTOHIDEGEXPRESSION:
-		        case INTOHIDELEXPRESSION:
-		        default:
-		            break;
+					break;
+				case INTOHIDEGEXPRESSION:
+				case INTOHIDELEXPRESSION:
+				default:
+					break;
 			}
 			break;
 		case DROP:
 			switch ( val ) {
-		        case SKIPLEXPRESSION:
-		        case LOCALEXPRESSION:
-		        case HIDELEXPRESSION:
+				case SKIPLEXPRESSION:
+				case LOCALEXPRESSION:
+				case HIDELEXPRESSION:
 					if ( setunset ) val = DROPLEXPRESSION;
-		            break;
-		        case DROPLEXPRESSION:
+					break;
+				case DROPLEXPRESSION:
 					if ( !setunset ) val = LOCALEXPRESSION;
-		            break;
-		        case SKIPGEXPRESSION:
-		        case GLOBALEXPRESSION:
-		        case HIDEGEXPRESSION:
+					break;
+				case SKIPGEXPRESSION:
+				case GLOBALEXPRESSION:
+				case HIDEGEXPRESSION:
 					if ( setunset ) val = DROPGEXPRESSION;
-		            break;
-		        case DROPGEXPRESSION:
+					break;
+				case DROPGEXPRESSION:
 					if ( !setunset ) val = GLOBALEXPRESSION;
-		            break;
-		        case HIDDENLEXPRESSION:
+					break;
+				case HIDDENLEXPRESSION:
 				case UNHIDELEXPRESSION:
 					if ( setunset ) val = DROPHLEXPRESSION;
-		            break;
-		        case HIDDENGEXPRESSION:
+					break;
+				case HIDDENGEXPRESSION:
 				case UNHIDEGEXPRESSION:
 					if ( setunset ) val = DROPHGEXPRESSION;
-		            break;
-		        case DROPHLEXPRESSION:
+					break;
+				case DROPHLEXPRESSION:
 					if ( !setunset ) val = HIDDENLEXPRESSION;
-		            break;
-		        case DROPHGEXPRESSION:
+					break;
+				case DROPHGEXPRESSION:
 					if ( !setunset ) val = HIDDENGEXPRESSION;
-		            break;
-		        case INTOHIDEGEXPRESSION:
-		        case INTOHIDELEXPRESSION:
-		        default:
-		            break;
+					break;
+				case INTOHIDEGEXPRESSION:
+				case INTOHIDELEXPRESSION:
+				default:
+					break;
 			}
 			break;
 		case HIDE:
 			switch ( val ) {
 				case DROPLEXPRESSION:
-		        case SKIPLEXPRESSION:
-		        case LOCALEXPRESSION:
+				case SKIPLEXPRESSION:
+				case LOCALEXPRESSION:
 					if ( setunset ) val = HIDELEXPRESSION;
-		            break;
-		        case HIDELEXPRESSION:
+					break;
+				case HIDELEXPRESSION:
 					if ( !setunset ) val = LOCALEXPRESSION;
-		            break;
+					break;
 				case DROPGEXPRESSION:
-		        case SKIPGEXPRESSION:
-		        case GLOBALEXPRESSION:
+				case SKIPGEXPRESSION:
+				case GLOBALEXPRESSION:
 					if ( setunset ) val = HIDEGEXPRESSION;
-		            break;
-		        case HIDEGEXPRESSION:
+					break;
+				case HIDEGEXPRESSION:
 					if ( !setunset ) val = GLOBALEXPRESSION;
-		            break;
-		        case INTOHIDEGEXPRESSION:
-		        case INTOHIDELEXPRESSION:
-		        default:
-		            break;
+					break;
+				case INTOHIDEGEXPRESSION:
+				case INTOHIDELEXPRESSION:
+				default:
+					break;
 			}
 			break;
 		case UNHIDE:
 			switch ( val ) {
-		        case HIDDENLEXPRESSION:
-		        case DROPHLEXPRESSION:
+				case HIDDENLEXPRESSION:
+				case DROPHLEXPRESSION:
 					if ( setunset ) val = UNHIDELEXPRESSION;
-		            break;
+					break;
 				case UNHIDELEXPRESSION:
 					if ( !setunset ) val = HIDDENLEXPRESSION;
-		            break;
-		        case HIDDENGEXPRESSION:
-		        case DROPHGEXPRESSION:
+					break;
+				case HIDDENGEXPRESSION:
+				case DROPHGEXPRESSION:
 					if ( setunset ) val = UNHIDEGEXPRESSION;
-		            break;
+					break;
 				case UNHIDEGEXPRESSION:
 					if ( !setunset ) val = HIDDENGEXPRESSION;
-		            break;
-		        case INTOHIDEGEXPRESSION:
-		        case INTOHIDELEXPRESSION:
-		        default:
-		            break;
+					break;
+				case INTOHIDEGEXPRESSION:
+				case INTOHIDELEXPRESSION:
+				default:
+					break;
 			}
 			break;
 		case INTOHIDE:
 			switch ( val ) {
-		        case HIDDENLEXPRESSION:
-		        case HIDDENGEXPRESSION:
+				case HIDDENLEXPRESSION:
+				case HIDDENGEXPRESSION:
 					MesPrint("&Expression is already hidden");
 					return(-1);
-		        case DROPHLEXPRESSION:
-		        case DROPHGEXPRESSION:
+				case DROPHLEXPRESSION:
+				case DROPHGEXPRESSION:
 				case UNHIDELEXPRESSION:
 				case UNHIDEGEXPRESSION:
-					MesPrint("&Cannot unhide and put intohide expression in the same module");
-					return(-1);
+					if ( setunset ) {
+						MesPrint("&Cannot unhide/drop and put intohide expression in the same module");
+						return(-1);
+					}
+					break;
 				case LOCALEXPRESSION:
 				case DROPLEXPRESSION:
-		        case SKIPLEXPRESSION:
+				case SKIPLEXPRESSION:
 				case HIDELEXPRESSION:
 					if ( setunset ) val = INTOHIDELEXPRESSION;
 					break;
 				case GLOBALEXPRESSION:
 				case DROPGEXPRESSION:
-		        case SKIPGEXPRESSION:
+				case SKIPGEXPRESSION:
 				case HIDEGEXPRESSION:
 					if ( setunset ) val = INTOHIDEGEXPRESSION;
 					break;
-		        default:
-		            break;
+				case INTOHIDELEXPRESSION:
+					if ( !setunset ) val = LOCALEXPRESSION;
+					break;
+				case INTOHIDEGEXPRESSION:
+					if ( !setunset ) val = GLOBALEXPRESSION;
+					break;
+				default:
+					break;
 			}
 			break;
 		default:
@@ -1508,7 +1517,7 @@ int SetExpr(UBYTE *s, int setunset, int par)
 			w = &(Expressions[i].status);
 			*w = SetExprCases(par,setunset,*w);
 			if ( *w < 0 ) error = 1;
-			if ( par == HIDE && setunset == 1 )
+			if ( ( par == HIDE || par == INTOHIDE ) && setunset == 1 )
 				Expressions[i].hidelevel = AC.HideLevel;
 		}
 		return(0);
@@ -1604,6 +1613,13 @@ int CoIntoHide(UBYTE *inp) {
 
 /*
   	#] CoIntoHide : 
+  	#[ CoNoIntoHide :
+*/
+
+int CoNoIntoHide(UBYTE *inp) { return(SetExpr(inp,0,INTOHIDE)); }
+
+/*
+  	#] CoNoIntoHide : 
   	#[ CoNoHide :
 */
 

--- a/sources/compiler.c
+++ b/sources/compiler.c
@@ -182,6 +182,7 @@ static KEYWORD com2commands[] = {
 	,{"ndrop",          (TFUN)CoNoDrop,           SPECIFICATION,PARTEST}
 	,{"nfactorize",     (TFUN)CoNFactorize,       TOOUTPUT,     PARTEST}
 	,{"nhide",          (TFUN)CoNoHide,           SPECIFICATION,PARTEST}
+	,{"nintohide",      (TFUN)CoNoIntoHide,       SPECIFICATION,PARTEST}
 	,{"normalize",      (TFUN)CoNormalize,        STATEMENT,    PARTEST}
 	,{"notinparallel",  (TFUN)CoNotInParallel,    SPECIFICATION,PARTEST}
 	,{"nskip",          (TFUN)CoNoSkip,           SPECIFICATION,PARTEST}

--- a/sources/declare.h
+++ b/sources/declare.h
@@ -1159,6 +1159,7 @@ extern int    CoPushHide(UBYTE *);
 extern int    CoPopHide(UBYTE *);
 extern int    CoHide(UBYTE *);
 extern int    CoIntoHide(UBYTE *);
+extern int    CoNoIntoHide(UBYTE *);
 extern int    CoNoHide(UBYTE *);
 extern int    CoUnHide(UBYTE *);
 extern int    CoNoUnHide(UBYTE *);


### PR DESCRIPTION
These commits make `IntoHide;` behave as described in the manual, resolving #10 , and also add an `NIntoHide` which allows one to cancel the current `IntoHide` plans. The "order of precedence" in `SetExprCases` is a little tricky, but I think this works as you would expect...