### PR TITLE
fix: repeat if sum creates dummy indices

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -3794,6 +3794,32 @@ assert stdout =~ exact_pattern(<<'EOF')
    {}: -10 -20 30
 EOF
 *--#] Issue599 : 
+*--#[ Issue615 :
+#-
+Off stats;
+
+Index i1,i2,i3,i4;
+CFunction f;
+Set sumind: i2,i3;
+
+Local test1 = f(i1,i2,i3,i4)^2;
+Local test2 = f(i1,i2,i3,i4)^2;
+
+Repeat;
+	If (Match(f(?a,i1?sumind$sum,?b))) Sum $sum;
+EndRepeat;
+InExpression test2;
+	Repeat;
+		If (Match(f(?a,i1?!dummyindices_$sum,?b))) Sum $sum;
+	EndRepeat;
+EndInExpression;
+
+Print;
+.end
+assert succeeded?
+assert result("test1") =~ expr("f(i1,N1_?,N2_?,i4)^2")
+assert result("test2") =~ expr("f(N1_?,N2_?,N3_?,N4_?)^2")
+*--#] Issue615 :
 *--#[ Issue633 :
 s x,y,z;
 c f;

--- a/sources/proces.c
+++ b/sources/proces.c
@@ -3609,7 +3609,13 @@ SkipCount:	level++;
 						if ( WildFill(BHEAD ow,term,op) < 0 ) goto GenCall;
 						AR.CompressPointer = op;
 						i = ow[0];
-						for ( j = 0; j < i; j++ ) term[j] = ow[j];
+						WORD term_changed = 0;
+						for ( j = 0; j < i; j++ ) {
+							if ( term[j] != ow[j] ) term_changed = 1;
+							term[j] = ow[j];
+						}
+						// If the term was modified by WildFill, set RepCount.
+						if ( term_changed ) *AN.RepPoint = 1;
 						AT.WorkPointer = ow;
 						ReNumber(BHEAD term);
 						goto Renormalize;


### PR DESCRIPTION
This fixes #615 , but not the other "mode" of `sum` (`TYPESUMFIX`), i.e. if we have something like `sum $sumind,1,2,3,4;`.

I am not sure yet how to fix things in that case: it is inside the call of Generator here
https://github.com/form-dev/form/blob/d9a3230f13d5f9199653d07584067673ce239de7/sources/proces.c#L3529
where we need to repeat the statements of the repeat block, right? The term we started with disappears. Setting `RepCount` before or after the call of `Generator` here doesn't work.