### PR TITLE
StrictRounding statement for floats

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -1415,6 +1415,26 @@ assert result("ATANH") =~ expr("
        - 6.08698087464190136361e-01*atanh( - 5.4321e-01)
 ")
 *--#] evaluate_atanh : 
+*--#[ strictrounding :
+#StartFloat 6d
+CFunction f;
+Local F1 = 1.23456789e-4+f(1.0)+f(1.0000001);
+Print;
+.sort
+
+Skip F1;
+Local F2 = F1;
+StrictRounding 4d;
+Argument f;
+	StrictRounding;
+EndArgument;
+Print;
+.end
+#pend_if wordsize == 2
+assert succeeded?
+assert result("F1") =~ expr("1.23457e-04 + f(1.0e+00) + f(1.0e+00)")
+assert result("F2") =~ expr("1.235e-04 + 2*f(1.0e+00)")
+*--#] strictrounding : 
 *--#[ float_error :
 Evaluate;
 ToFloat;

--- a/doc/manual/float.tex
+++ b/doc/manual/float.tex
@@ -51,6 +51,44 @@ functions that \FORM{} knows about will be evaluated. The currently allowed
 arguments are the functions mzv\_, euler\_, sqrt\_ and mzvhalf\_. If any 
 (or more than one) of these are specified only those functions will be 
 evaluated.
+\item[strictrounding] This statement rounds floating point numbers to a 
+given precision. The syntax is
+\begin{verbatim}
+    strictrounding [precision];
+\end{verbatim}
+where precision is an optional argument that specifies the rounding 
+precision in either digits or bits, using the same syntax as 
+\texttt{\#startfloat}. If no argument is given, this statement rounds 
+the floating point coefficients to the default precision. Internally, 
+the GMP and mpfr libraries may use extra precision beyond that set by 
+\texttt{\#startfloat}. As a result, terms may not merge due to this 
+extra precision. For example:
+\begin{verbatim}
+    #startfloat 6d
+    CFunction f;
+    Local F = f(1.0)+f(1.0000001);
+    Print;
+    .sort
+\end{verbatim}
+results in \texttt{F = f(1.0e+00)+f(1.0e+00);}. Although it may appear 
+that the terms should merge, the extra precision maintained by GMP 
+prevents this, even though it is not displayed at 6 digits of 
+precision. Using the strictrounding statement, one can force rounding 
+to exactly 6 digits. Indeed:
+\begin{verbatim}
+    Argument f;
+        strictrounding;
+    Argument;
+    Print;
+    .end
+\end{verbatim}
+results in \texttt{F = 2*f(1.0e+00);}.
+Notice that rounding in bits may produce unexpected results when viewed 
+in decimal digits. For example, the decimal number 1.1e-4 cannot be 
+represented exactly in binary. Its binary representation, up to 20 bits of precision, is 
+$1.1100110101011111101*2^{-14}$. When rounded to 5 bits, this becomes 
+$1.1101*2^{-14}$, which in decimal digits appears as 
+1.10626220703125e-04.
 \item[Format floatprecision] This instruction controls how many digits are 
 displayed when printing floating point numbers. It only affects output 
 formatting and does not influence the internal precision or accuracy of 

--- a/doc/manual/statements.tex
+++ b/doc/manual/statements.tex
@@ -5357,6 +5357,18 @@ indicating the arguments that should be treated. If no arguments are
 specified all arguments will be treated. \vspace{10mm}
 
 %--#] splitlastarg : 
+%--#[ strictrounding :
+\section{strictrounding}
+\label{substaevaluate}
+
+\noindent \begin{tabular}{ll}
+Type & Executable statement\\
+Syntax & strictrounding [$<$precision$>$]; \\ 
+\end{tabular} \vspace{4mm}
+
+\noindent See chapter~\ref{floatingpoint} on the floating point capability.
+ 
+%--#] strictrounding : 
 %--#[ stuffle :
 %
 \section{stuffle}

--- a/sources/compcomm.c
+++ b/sources/compcomm.c
@@ -373,7 +373,7 @@ int CoFormat(UBYTE *s)
 #ifdef WITHFLOAT
 			else if ( key->flags == 5 ) {
 /*
-				Syntax: Format FloatPrecision number;
+				Syntax: Format FloatPrecision [precision];
 				        Format FloatPrecision off;
 */
 				while ( FG.cTable[*s] == 0 ) s++;
@@ -391,10 +391,7 @@ int CoFormat(UBYTE *s)
 				}
 				else if ( FG.cTable[*s] == 1 ) {
 					ss = s;
-					AO.FloatPrec = 0;
-					while ( *s <= '9' && *s >= '0' )
-						AO.FloatPrec = 10*AO.FloatPrec + (*s++ - '0');
-					while ( *s == ' ' || *s == '\t' || *s == ',' ) s++;
+					ParseNumber(AO.FloatPrec,s)
 /*
 					The precision can either be in digits or bits. 
 					AO.FloatPrec is in digits. 
@@ -402,6 +399,7 @@ int CoFormat(UBYTE *s)
 					if ( tolower(*s) == 'd' ) { s++; }
 					else if ( tolower(*s) == 'b' ) { AO.FloatPrec = AO.FloatPrec*log10(2.0); s++; }
 					else { s = ss; goto WrongOption; }
+					while ( *s == ' ' || *s == '\t' || *s == ',' ) s++;
 					if ( *s ) { s = ss; goto WrongOption; }
 				}
 				else {

--- a/sources/compiler.c
+++ b/sources/compiler.c
@@ -218,6 +218,9 @@ static KEYWORD com2commands[] = {
 	,{"splitarg",       (TFUN)CoSplitArg,         STATEMENT,    PARTEST}
 	,{"splitfirstarg",  (TFUN)CoSplitFirstArg,    STATEMENT,    PARTEST}
 	,{"splitlastarg",   (TFUN)CoSplitLastArg,     STATEMENT,    PARTEST}
+#ifdef WITHFLOAT
+	,{"strictrounding", (TFUN)CoStrictRounding,   STATEMENT,    PARTEST}
+#endif
 	,{"stuffle",        (TFUN)CoStuffle,          STATEMENT,    PARTEST}
 	,{"sum",            (TFUN)CoSum,              STATEMENT,    PARTEST}
 	,{"switch",         (TFUN)CoSwitch,           STATEMENT,    PARTEST}

--- a/sources/declare.h
+++ b/sources/declare.h
@@ -1743,6 +1743,8 @@ SBYTE *ReadFloat(SBYTE *);
 UBYTE *CheckFloat(UBYTE *,int *);
 void SetfFloatPrecision(LONG);
 int EvaluateFun(PHEAD WORD *, WORD, WORD *);
+int CoStrictRounding(UBYTE *);
+int StrictRounding(PHEAD WORD *, WORD, WORD, WORD);
 #endif
 
 /*

--- a/sources/ftypes.h
+++ b/sources/ftypes.h
@@ -605,6 +605,7 @@ typedef int (*TFUN1)();
 #define TYPEEXPAND 88
 #define TYPETOFLOAT 89
 #define TYPETORAT 90
+#define TYPESTRICTROUNDING 91
 #endif
 
 /*

--- a/sources/proces.c
+++ b/sources/proces.c
@@ -3994,6 +3994,10 @@ CommonEnd:
 					AT.WorkPointer = term + *term;
 					if ( ToRat(BHEAD term,level) ) goto GenCall;
 					goto Return0;
+				  case TYPESTRICTROUNDING:
+					AT.WorkPointer = term + *term;
+					if ( StrictRounding(BHEAD term,level,C->lhs[level][2],C->lhs[level][3]) ) goto GenCall;
+					goto Return0;
 #endif
 				}
 				goto SkipCount;


### PR DESCRIPTION
This PR introduces a new `StrictRounding` statement that rounds floats to a specified precision. If no precision is given, the default precision is used. This can be useful to trim the extra precision used by GMP. This also resolves #698. 

Similar to the floating point precision, the precision in `StrictRounding` can be specified in digits or bits. For example:
- the base 10 number 1.1e-4 cannot be written as a finite sequence in base 2: it is 1.1100110101011111101\*2^(-14). So, when we round to 5 bits, we get 1.1101*2^(-14) in bits. However, in base 10, this is written as 1.10626220703125e-04.

At the moment, the implementation makes use of the `GMP` functions `mpf_get_str` and `mpf_set_str`. Maybe in the feature we can come up with our own algorithm to do the rounding?

Example usage:
```
#-
Off statistics;
#StartFloat 6d
CFunction f;
Local F = f(1.0)+f(1.0000001);
L G = 1.23456789e-4;
Print;
.sort

StrictRounding 4d;
Argument f;
	StrictRounding;
EndArgument;
Print;
.end
```
results in 
```
   F =
      f(1.0e+00) + f(1.0e+00);

   G =
      1.23457e-04;


   F =
      2*f(1.0e+00);

   G =
      1.235e-04;
```