### PR TITLE
fix: regression: save file compatibility

### DIFF
--- a/sources/structs.h
+++ b/sources/structs.h
@@ -423,7 +423,17 @@ typedef struct SyMbOl {			/* Don't change unless altering .sav too */
 	WORD	node;
 	WORD	namesize;
 	WORD	dimension;			/* For dimensionality checks */
+#if BITSINWORD == 32
+	UBYTE d_u_m_m_y[8];		/* Padding for sav compatibility */
+#elif BITSINWORD == 16
+	UBYTE d_u_m_m_y[4];		/* Padding for sav compatibility */
+#endif
 } *SYMBOLS;
+#if BITSINWORD == 32
+STATIC_ASSERT(sizeof(struct SyMbOl) == 48);
+#elif BITSINWORD == 16
+STATIC_ASSERT(sizeof(struct SyMbOl) == 24);
+#endif
 
 /**
  *
@@ -439,6 +449,11 @@ typedef struct InDeX {			/* Don't change unless altering .sav too */
 	WORD	node;
 	WORD	namesize;
 } *INDICES;
+#if BITSINWORD == 32
+STATIC_ASSERT(sizeof(struct InDeX) == 40);
+#elif BITSINWORD == 16
+STATIC_ASSERT(sizeof(struct InDeX) == 20);
+#endif
 
 /**
  *
@@ -452,7 +467,17 @@ typedef struct VeCtOr {			/* Don't change unless altering .sav too */
 	WORD	node;
 	WORD	namesize;
 	WORD	dimension;			/* For dimensionality checks */
+#if BITSINWORD == 32
+	UBYTE d_u_m_m_y[8];		/* Padding for sav compatibility */
+#elif BITSINWORD == 16
+	UBYTE d_u_m_m_y[4];		/* Padding for sav compatibility */
+#endif
 } *VECTORS;
+#if BITSINWORD == 32
+STATIC_ASSERT(sizeof(struct VeCtOr) == 40);
+#elif BITSINWORD == 16
+STATIC_ASSERT(sizeof(struct VeCtOr) == 20);
+#endif
 
 /**
  *  Contains all information about a function. Also used for tables.
@@ -475,6 +500,11 @@ typedef struct FuNcTiOn {  /* Don't change unless altering .sav too */
 	WORD    maxnumargs;
 	WORD    minnumargs;
 } *FUNCTIONS;
+#if BITSINWORD == 32
+STATIC_ASSERT(sizeof(struct FuNcTiOn) == 72);
+#elif BITSINWORD == 16
+STATIC_ASSERT(sizeof(struct FuNcTiOn) == 36);
+#endif
 
 /**
  *


### PR DESCRIPTION
Commit 7ed2880 breaks compatibility of save files with previous versions. Restore compatibilty by adding manual padding to two of the structs, and also add a static_assert to the four structs which have commentary regarding save files to validate the size at compile time.

------------

Adding the static asserts mean that the code doesn't compile for 32 bits; this means that sav files created by 32bit form are not compatible with 64bit form, and vice versa. I suppose we know this already.

I would like to keep the assertions; maybe it suffices to wrap them in `#if ( BITSINWORD == 64 )` ?