### PR TITLE
fix: use a scratch buffer in simp3btoken

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2220,6 +2220,63 @@ assert stdout =~ exact_pattern(<<'EOF')
    S1(spectator)(5)
 EOF
 *--#] Issue231 :
+*--#[ Issue251_1
+#-
+Symbol x,a0,...,a3;
+Local F = <a0*x^0>+...+<a3*x^3>;
+Bracket x;
+.sort
+
+Local G =
+	+ 1 / F[1]
+	+ x * (-F[x]) / F[1]^2
+	+ x^2 * (F[x]^2 - F[1]*F[x^2]) / F[1]^3
+	+ x^3 * (-F[x]^3 + 2*F[1]*F[x]*F[x^2] - F[1]^2*F[x^3]) / F[1]^4
+	;
+Print +s G;
+.end
+assert succeeded?
+assert result("G") =~ expr("
+       + a0^-1
+       - x*a0^-2*a1
+       + x^2*a0^-3*a1^2
+       - x^2*a0^-2*a2
+       - x^3*a0^-4*a1^3
+       + 2*x^3*a0^-3*a1*a2
+       - x^3*a0^-2*a3
+")
+*--#] Issue251_1
+*--#[ Issue251_2
+#-
+Symbol x,a0,...,a3;
+Local F = <a0*x^0>+...+<a3*x^3>;
+Bracket x;
+.sort
+
+Local G =
+	+ 1 / F[1]
+	+ x * (-F[x]) / F[1]^2
+	+ x^2 * (F[x]^2 - F[1]*F[x^2]) / F[1]^3
+	+ x^3 * (-F[x]^3 + 2*F[1]*F[x]*F[x^2] - F[1]^2*F[x^3]
+		#do i = 1,100
+			+ F[1]^1
+		#enddo
+	) / F[1]^4
+	;
+Print +s G;
+.end
+assert succeeded?
+assert result("G") =~ expr("
+       + a0^-1
+       - x*a0^-2*a1
+       + x^2*a0^-3*a1^2
+       - x^2*a0^-2*a2
+       - x^3*a0^-4*a1^3
+       + 100*x^3*a0^-3
+       + 2*x^3*a0^-3*a1*a2
+       - x^3*a0^-2*a3
+")
+*--#] Issue251_2
 *--#[ Issue253 :
 * Memory error for local $-variable in TFORM
 #$x = 0;


### PR DESCRIPTION
Issue #251 crashes because "fill" overtakes "s" and produces malformed tokens, leading to an infinite loop. Avoid this possibility by writing the output tokens into a scratch buffer, and copy the result back at the end.

Additionally, re-allocate the buffers if fill is "close to" the end of the scratch buffer. Here "close to" is a guess at how much space might be required per iteration.

--------------
Here is a proposed fix of #251. The "magic" `+20` is no longer required, but instead there is a magic "how much space is required at the end of the token buffer for each iteration of the while loop?" At least in the future if someone reports that `fill` goes out of bounds of `tmptokens` it is clear what is going on.

Some `TEMPTY` space is still required at the start of `AC.tokens` before the call of `simp3btoken`: `s` and `t` pointers end up in this space even if initially they are moved beyond it.

I don't measure any performance penalty due to the allocations (they are not all that large) but in principle one could introduce a permanent `AC.tmptokens` to serve as scratch space without the allocations.

Any comments?