### PR TITLE
fix: infinite loops in parsing/tokenising

### DIFF
--- a/sources/dict.c
+++ b/sources/dict.c
@@ -801,7 +801,7 @@ int SetDictionaryOptions(UBYTE *options)
 	AO.CurDictInDollars = DICT_NOTINDOLLARS;
 	while ( *s ) {
 		opt = s;
-		while ( *s && *s != ',' && *s != ' ' ) s++;
+		while ( *s && *s != ',' ) s++;
 		c = *s; *s = 0;
 		if ( opt[0] == '$' && opt[1] == 0 ) {
 			AO.CurDictInDollars = DICT_INDOLLARS;

--- a/sources/token.c
+++ b/sources/token.c
@@ -318,7 +318,8 @@ dofloat:
 							}
 							else if ( spec == -1 ) {
 								MesPrint("&The floating point system has not been started: %s",in);
-	            		        if ( !error ) error = 1;
+								if ( !error ) error = 1;
+								in++;
 							}
 							else {
 								UBYTE *a = s; s = in; in = a;


### PR DESCRIPTION
This fixes two infinite loops after error conditions, discovered by afl++.

Closes #664 