### PR TITLE
fix: when inparallel, load unhide expr from hide file

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -3935,6 +3935,35 @@ Print;
 assert succeeded?
 assert result("F") =~ expr("mzv_ + euler_ + mzvhalf_")
 *--#] Issue646 :
+*--#[ Issue647 :
+#-
+#define NEXPR "4"
+
+Symbol x;
+#do i = 1,`NEXPR'
+    Local F`i' = x^`i';
+    Local G`i' = x^`i';
+#enddo
+.sort
+Hide;
+.sort
+UnHide;
+
+#do i = 1,`NEXPR'
+    Local diff`i' = F`i' - G`i';
+#enddo
+ModuleOption inparallel;
+.sort
+
+Print;
+.end
+#pend_if mpi?
+assert succeeded?
+assert result("diff1") =~ expr("0")
+assert result("diff2") =~ expr("0")
+assert result("diff3") =~ expr("0")
+assert result("diff4") =~ expr("0")
+*--#] Issue647 :
 *--#[ Issue664 :
 #-
 #StartFloat 64b

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -1614,7 +1614,8 @@ bucketstolen:;
 				}
 
 				position = AS.OldOnFile[i];
-				if ( e->status == HIDDENLEXPRESSION || e->status == HIDDENGEXPRESSION ) {
+				if ( e->status == HIDDENLEXPRESSION || e->status == HIDDENGEXPRESSION
+					|| e->status == UNHIDELEXPRESSION || e->status == UNHIDEGEXPRESSION ) {
 					AR.GetFile = 2; fi = AR.hidefile;
 				}
 				else {


### PR DESCRIPTION
The inparallel processing code must search for expressions in the hide file when they have status "unhide" as well as "hidden".

The new test does not work in parform.

Closes #647 