### PR TITLE
Implement #continuedo <number>

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -2390,11 +2390,91 @@ assert succeeded?
 assert result("F") =~ expr("f(1,2,4,5)")
 *--#] Issue243_1 : 
 *--#[ Issue243_2 :
+NF f;
+L F = 1;
+#define i "9"
+#do i=1,2
+  #do i=1,3
+    #do i=1,8
+      #if `i' == 3
+        #continuedo 2
+      #endif
+      multiply right, f(`i');
+    #enddo
+    multiply right, f(-`i');
+  #enddo
+  multiply right, f(-`i');
+#enddo
+multiply right, f(`i');
+chainin f;
+P;
+.end
+assert succeeded?
+assert result("F") =~ expr("f(1,2,1,2,1,2,-1,1,2,1,2,1,2,-2,9)")
+*--#] Issue243_2 : 
+*--#[ Issue243_3 :
+NF f;
+L F = 1;
+#do i=1,3
+  #do i=1,2
+    #continuedo 0
+    multiply right, f(`i');
+  #enddo
+#enddo
+chainin f;
+P;
+.end
+assert succeeded?
+assert result("F") =~ expr("f(1,2,1,2,1,2)")
+*--#] Issue243_3 : 
+*--#[ Issue243_e1 :
 #continuedo
 .end
-assert preprocess_error?
-assert stdout =~ exact_pattern("#continuedo without #do")
-*--#] Issue243_2 : 
+assert preprocess_error?("#continuedo without #do")
+*--#] Issue243_e1 : 
+*--#[ Issue243_e2 :
+#do i=1,3
+  #continuedo -1
+#enddo
+.end
+assert preprocess_error?("Improper syntax of #continuedo instruction")
+*--#] Issue243_e2 : 
+*--#[ Issue243_e3 :
+#do i=1,3
+  #continuedo 1a
+#enddo
+.end
+assert preprocess_error?("Improper syntax of #continuedo instruction")
+*--#] Issue243_e3 : 
+*--#[ Issue243_e4 :
+#do i=1,3
+  #continuedo 2
+#enddo
+.end
+assert preprocess_error?("Too many loop levels requested in #continuedo instruction")
+*--#] Issue243_e4 : 
+*--#[ Issue243_e5 :
+#procedure foo
+  #continuedo
+#endprocedure
+#do i=1,3
+  #call foo
+#enddo
+.end
+assert preprocess_error?("Trying to jump out of a procedure with a #continuedo instruction")
+*--#] Issue243_e5 : 
+*--#[ Issue243_e6 :
+#procedure foo
+  #continuedo 2
+#endprocedure
+#do i=1,3
+  #do j=1,3
+    #call foo
+  #enddo
+#enddo
+.end
+assert preprocess_error?("Trying to jump out of a procedure with a #continuedo instruction")
+*--#] Issue243_e6 : 
 *--#[ Issue392_ContinuationLines_1 :
 #: ContinuationLines 1
 * Setting ContinuationLines to 0 should remove continuation line limit.

--- a/doc/manual/prepro.tex
+++ b/doc/manual/prepro.tex
@@ -632,6 +632,28 @@ sign in column 1 in longer expressions.
 The default commentary character is $\ast$.
 
 %--#] commentchar : 
+%--#[ continuedo :
+
+\section{\#continuedo}
+\label{precontinuedo}
+
+\noindent Syntax:
+
+\#continuedo [{\tt<}number{\tt>}]
+
+\noindent See also \#do (\ref{predo}) and \#enddo (\ref{preenddo})
+
+\noindent The \#continuedo\index{\#continuedo} instruction allows one to
+jump to the next iteration of a \#do loop.
+If a (nonzero integer) number is specified
+it indicates the number of enclosing loops
+that the program should continue to the next iteration of.
+Control will continue at the beginning of the next iteration
+of the enclosing loop indicated by `number'.
+The default value is one.
+If the value is zero the instruction has no effect.
+
+%--#] continuedo : 
 %--#[ create :
  
 \section{\#create}


### PR DESCRIPTION
This patch adds a multi-loop extension of the `#continuedo` preprocessor instruction (https://github.com/form-dev/form/pull/443). It uses the fact that `#continuedo n` is equivalent to `#breakdo (n-1)` followed by a `#continue` for the remaining outermost loop.

Tests and documentation are also added.