### PR TITLE
fix: regression: avoid null pointer dereference in CleanDollarFactors

### DIFF
--- a/sources/dollar.c
+++ b/sources/dollar.c
@@ -3556,8 +3556,9 @@ void CleanDollarFactors(DOLLARS d)
 	int i;
 	if ( d->nfactors >= 1 ) {
 		for ( i = 0; i < d->nfactors; i++ ) {
-			if ( d->factors[i].where )
-				M_free(d->factors[i].where,"dollar factors");
+			if ( d->factors )
+				if ( d->factors[i].where )
+					M_free(d->factors[i].where,"dollar factors");
 		}
 	}
 	if ( d->factors ) {


### PR DESCRIPTION
This function can be called with nfactors = 1, but with no array allocated on d->factors.