### PR TITLE
Stop using K&R C features that have been removed

### DIFF
--- a/sources/evaluate.c
+++ b/sources/evaluate.c
@@ -3,7 +3,6 @@
 */
 
 #include "form3.h"
-#include <stdarg.h>
 #include <gmp.h>
 #include <mpfr.h>
 

--- a/sources/form3.h
+++ b/sources/form3.h
@@ -292,16 +292,13 @@ template<typename T> struct calc {
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>
-#ifdef ANSI
 #include <stdarg.h>
 #include <time.h>
-#endif
 #ifdef WINDOWS
 #include "fwin.h"
 #endif
 #ifdef UNIX
 #include <unistd.h>
-#include <time.h>
 #include <fcntl.h>
 #include <sys/file.h>
 #include "unix.h"

--- a/sources/ftypes.h
+++ b/sources/ftypes.h
@@ -168,24 +168,11 @@
 	The typedefs are to allow the compilers to do better error checking.
 */
 
-#ifdef ANSI
 typedef void (*PVFUNWP)(WORD *);
-#ifdef INTELCOMPILER
-typedef void (*PVFUNV)();
-typedef int (*CFUN)();
-#else
 typedef void (*PVFUNV)(void);
 typedef int (*CFUN)(void);
-#endif
 typedef int (*TFUN)(UBYTE *);
 typedef int (*TFUN1)(UBYTE *,int);
-#else
-typedef void (*PVFUNWP)();
-typedef void (*PVFUNV)();
-typedef int (*CFUN)();
-typedef int (*TFUN)();
-typedef int (*TFUN1)();
-#endif
 
 
 #define NOAUTO 0

--- a/sources/message.c
+++ b/sources/message.c
@@ -133,13 +133,7 @@ int MesWork(void)
 	the tabulator in the print "" statement.
 */
 
-int
-#ifdef ANSI
-MesPrint(const char *fmt, ... )
-#else
-MesPrint(va_alist)
-va_dcl
-#endif
+int MesPrint(const char *fmt, ... )
 {
 	GETIDENTITY
 	char Out[MAXLINELENGTH+14], *stopper, *t, *s, *u, c, *carray;
@@ -152,13 +146,8 @@ va_dcl
 	LONG (*OldWrite)(int handle, UBYTE *buffer, LONG size) = WriteFile;
 	/*:[19apr2004 mt]*/
 	va_list ap;
-#ifdef ANSI
 	va_start(ap,fmt);
 	s = (char *)fmt;
-#else
-	va_start(ap);
-	s = va_arg(ap,char *);
-#endif
 #ifdef WITHMPI
 	/*
 	 * On slaves, if AS.printflag is

--- a/sources/sch.c
+++ b/sources/sch.c
@@ -35,24 +35,6 @@
 
 #include "form3.h"
 
-#ifdef ANSI
-#include <stdarg.h>
-#else
-#ifdef mBSD
-#include <varargs.h>
-#else
-#ifdef VMS
-#include <varargs.h>
-#else
-typedef UBYTE *va_list;
-#define va_dcl int va_alist;
-#define va_start(list) list = (UBYTE *) &va_alist
-#define va_end(list)
-#define va_arg(list,mode) (((mode *)(list += sizeof(mode)))[-1])
-#endif
-#endif
-#endif
-
 static int startinline = 0;
 static char fcontchar = '&';
 static int noextralinefeed = 0;

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -2497,13 +2497,8 @@ typedef struct AllGlobals {
 #define BHEAD0
 #endif
 
-#ifdef ANSI
 typedef int (*WCN)(PHEAD WORD *,WORD *,WORD,WORD);
 typedef int (*WCN2)(PHEAD WORD *,WORD *);
-#else
-typedef int (*WCN)();
-typedef int (*WCN2)();
-#endif
  
 typedef WORD (*COMPARE)(PHEAD WORD *,WORD *,WORD);
 

--- a/sources/tools.c
+++ b/sources/tools.c
@@ -2081,28 +2081,19 @@ char *LongLongCopy(off_t *y, char *to)
 		Routine produces a string with the date and time of the run
 */
 
-#ifdef ANSI
-#else
-#ifdef mBSD
+#if defined(ANSI) || defined(mBSD)
 #else
 static char notime[] = "";
-#endif
 #endif
 
 UBYTE *MakeDate(void)
 {
-#ifdef ANSI
-	time_t tp;
-	time(&tp);
-	return((UBYTE *)ctime(&tp));
-#else
-#ifdef mBSD
+#if defined(ANSI) || defined(mBSD)
 	time_t tp;
 	time(&tp);
 	return((UBYTE *)ctime(&tp));
 #else
 	return((UBYTE *)notime);
-#endif
 #endif
 }
 


### PR DESCRIPTION
C23 ([N3054 (PDF)](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3054.pdf)) has removed K&R1-style function declarations from its syntax ([N2432 (PDF)](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2432.pdf)). Maybe it's time to assume C89-compatible compilers are always available.

For example, `MesPrint` is defined in `message.c` as follows:
```c
int
#ifdef ANSI
MesPrint(const char *fmt, ... )
#else
MesPrint(va_alist)
va_dcl
#endif
{
...
```

As a result, VSCode can't jump to `MesPrint` using "Go to Definition".

We also assumes `<stdarg.h>` is always available.

We still use `ANSI` to select the date and timer implementations, though probably no one tries to compile FORM for freestanding environments where `<time.h>` and similar headers are not available (except for WebAssembly?). This code may need to be refactored in the future.

Note that there are many other places where K&R1 coding style is used (e.g., `return(0);`), but that's a separate issue (see also https://github.com/form-dev/form/discussions/712).