### PR TITLE
Upgrade FLINT from 3.3.1 to 3.4.0 in CI

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -12,7 +12,7 @@ inputs:
   flint_version:
     description: FLINT version to build.
     required: false
-    default: '3.3.1'
+    default: '3.4.0'
 
 runs:
   using: composite


### PR DESCRIPTION
See: https://flintlib.org/doc/history.html#flint-3-4-0

I'm not sure whether this upgrade includes improvements to rational arithmetic in FORM, but here it is.