### PR TITLE
Broken text in the manual: workaround for LaTeX2HTML prior to v2025

### DIFF
--- a/scripts/run-latex2html.sh
+++ b/scripts/run-latex2html.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 #
 # @file run-latex2html.sh
 #
 # Usage:
 #   run-latex2html.sh main.tex
 #
-set -eu
+set -euo pipefail
 
 if [ $# -ne 1 ]; then
   echo "Usage: $(basename "$0") main.tex" >&2
@@ -41,8 +41,10 @@ LATEX2HTML_INIT=$BINDIR/.latex2html-init
 "$LATEX2HTML" -init_file "$LATEX2HTML_INIT" "$MAIN_PATH"
 
 fix_html() {
-  # HREF="main.html#SECTION..." -> HREF="#SECTION..."
-  sed "s/$2.html#/#/g" "$1" >"$1.tmp"
+  # (1) HREF="main.html#SECTION..." -> HREF="#SECTION..."
+  # (2) workaround for latex2html < v2025
+  #     See: https://github.com/latex2html/latex2html/commit/b77ee98
+  sed "s/$2.html#/#/g" "$1" | sed 's/&&#x308;#305;/\&iuml;/g' >"$1.tmp"
   mv "$1.tmp" "$1"
 }
 


### PR DESCRIPTION
The current generated HTML file for the reference manual contains, in the section of the `content_` function:

> <img width="300" alt="image" src="https://github.com/user-attachments/assets/1951b39f-5c05-4ec9-bb2b-f7ab18d3729c" />

This is because LaTeX2HTML prior to v2025 fails to handle `co\"{\i}ncides` (see also https://github.com/latex2html/latex2html/commit/b77ee98e3d876562ecb6e81410656261551ce991).

This PR fixes it by simply replacing `&&#x308;#305;` in the generated file with `\&iuml;`:

> <img width="300" alt="image" src="https://github.com/user-attachments/assets/b1e82dda-312e-4150-8e26-73c393b7ee57" />

Alternative solutions can be (1) using LaTeX2HTML v2025 or later (which needs a change in CI), or (2) changing `co\"{\i}ncides` to `coincides` in the manual.