### PR TITLE
Warn about conflicting module options for $-variables

### DIFF
--- a/check/features.frm
+++ b/check/features.frm
@@ -2357,6 +2357,23 @@ discard;
 .end
 assert succeeded?
 *--#] ModuleOption_dollar_order : 
+*--#[ ModuleOption_dollar_warnings_1 :
+$a = 0;
+ModuleOption local,$a;
+ModuleOption local,$a;
+.end
+assert succeeded?
+*--#] ModuleOption_dollar_warnings_1 : 
+*--#[ ModuleOption_dollar_warnings_2 :
+ModuleOption local,$a;
+$b = 0;
+ModuleOption local,$b;
+ModuleOption sum,$b;
+.end
+assert return_value == 0
+assert warning?("Undefined $-variable in module option; option ignored: $a")
+assert warning?("Conflicting module options for $-variable; later option ignored: $b")
+*--#] ModuleOption_dollar_warnings_2 : 
 *--#[ Issue49 :
 * Add mul_ function for polynomial multiplications
 Symbols x,y,z;

--- a/sources/module.c
+++ b/sources/module.c
@@ -659,6 +659,7 @@ UBYTE * DoModDollar(UBYTE *s, int type)
 	UBYTE *name, c;
 	WORD number;
 	MODOPTDOLLAR *md;
+	int nummodopt;
 	while ( *s == '$' ) {
 /*
 		Read the name of the dollar
@@ -671,8 +672,22 @@ UBYTE * DoModDollar(UBYTE *s, int type)
 			c = *s; *s = 0;
 			number = GetDollar(name);
 			if ( number < 0 ) {
+				UBYTE *s1;
 				number = AddDollar(s,0,0,0);
-				Warning("Undefined $-variable in module statement");
+				s1 = strDup1((UBYTE *)"Undefined $-variable in module option; option ignored: $","Undefined $-variable in ModuleOption");
+				s1 =  AddToString(s1,name,0);
+				Warning((char *)s1);
+				M_free(s1,"Undefined $-variable in ModuleOption");
+			}
+			for ( nummodopt = 0; nummodopt < NumModOptdollars; nummodopt++ ) {
+				if ( number == ModOptdollars[nummodopt].number && type != ModOptdollars[nummodopt].type ) {
+					UBYTE *s1;
+					s1 = strDup1((UBYTE *)"Conflicting module options for $-variable; later option ignored: $","Conflicting $-variable in ModuleOption");
+					s1 = AddToString(s1,name,0);
+					Warning((char *)s1);
+					M_free(s1,"Conflicting $-variable in ModuleOption");
+					break;
+				}
 			}
 			md = (MODOPTDOLLAR *)FromList(&AC.ModOptDolList);
 			md->number = number;


### PR DESCRIPTION
This PR makes FORM emit a warning when `ModuleOption` is used for a $-variable in a conflicting way within the same module:
```form
Format 100;  * Default line width wraps warnings badly.
$a = 1;
ModuleOption local $a;
ModuleOption sum $a;
.end
```
```
test.frm Line 4 --> Warning: Conflicting module options for $-variable; later option ignored: $a
```

It also improves warnings for undefined $-variables:
```form
Format 100;
ModuleOption local $a;
.end
```
```
test.frm Line 2 --> Warning: Undefined $-variable in module option; option ignored: $a
```