### PR TITLE
Clarify the error message for missing zlibWrapper in non-Git builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -397,11 +397,11 @@ AM_CONDITIONAL([WITHZSTD], [test "x$with_zstd" = xyes])
 # Ensure zstd/zlibWrapper
 AS_IF([test -f "$srcdir/extern/zstd/zlibWrapper/zstd_zlibwrapper.h"], [],
 	[AC_PATH_PROG([GIT], [git])
-		AS_IF([test -n "$GIT"], [(cd "$srcdir" && "$GIT" submodule update --init)])])
+		AS_IF([test -n "$GIT" && (cd "$srcdir" && "$GIT" rev-parse --is-inside-work-tree >/dev/null 2>&1)], [(cd "$srcdir" && "$GIT" submodule update --init)])])
 AS_IF([test -f "$srcdir/extern/zstd/zlibWrapper/zstd_zlibwrapper.h"], [],
-	[AS_IF([test -d "$srcdir/.git"],
+	[AS_IF([test -e "$srcdir/.git"],
 		[AC_MSG_FAILURE([$srcdir/extern/zstd/zlibWrapper does not exist. Run git submodule update --init in the repository directory])],
-		[AC_MSG_FAILURE([$srcdir/extern/zstd/zlibWrapper does not exist])])])
+		[AC_MSG_FAILURE([$srcdir/extern/zstd/zlibWrapper does not exist. Copy the zlibWrapper directory from upstream (https://github.com/facebook/zstd)])])])
 
 # Check for flint
 AC_ARG_WITH([flint],


### PR DESCRIPTION
Even for `./configure --without-std`, we need `extern/zstd/zlibWrapper` at configure time.

This PR slightly improves the error message for non-standard builds from a GitHub source snapshot (equivalent to `git archive`), changing it from:
```
checking for git... /usr/bin/git
fatal: not a git repository (or any of the parent directories): .git
configure: error: in '/home/tueda/tmp/20260127/1/form-master':
configure: error: ./extern/zstd/zlibWrapper does not exist
See 'config.log' for more details
```
to
```
checking for git... /usr/bin/git
configure: error: in '/home/tueda/tmp/20260127/2/form-pr-build-zlibwrapper-handling':
configure: error: ./extern/zstd/zlibWrapper does not exist. Copy the zlibWrapper directory from upstream (https://github.com/facebook/zstd)
See 'config.log' for more details
```
which answers a possible FAQ.