### PR TITLE
docs(manual): workaround for inconsistent author formatting in LaTeX2HTML

### DIFF
--- a/doc/manual/manual.tex.in
+++ b/doc/manual/manual.tex.in
@@ -75,7 +75,11 @@
 \begin{titlepage}
 \title{\Huge FORM \\ \Large version \formversiondesc \\ \huge Reference manual}
 \date{\formdate}
-\author{J.A.M.~Vermaseren, J.~Davies, T.~Kaneko, J.~Kuipers, C.~Marinissen, B.~Ruijl, \\M.~Tentyukov, T.~Ueda and J.~Vollinga}
+\author{J.A.M.~Vermaseren, J.~Davies, T.~Kaneko, J.~Kuipers, C.~Marinissen, B.~Ruijl,
+%begin{latexonly}
+\\
+%end{latexonly}
+M.~Tentyukov, T.~Ueda and J.~Vollinga}
 \end{titlepage}
 \maketitle
 %\clearemptydoublepage


### PR DESCRIPTION
Currently, LaTeX2HTML renders the author list in the reference manual as:

<img width="502" height="210" alt="image" src="https://github.com/user-attachments/assets/d2d1dac2-00fa-47e0-ab65-3db9f68efe49" />

See also: https://github.com/latex2html/latex2html/issues/89.

This PR makes my name bold again by avoiding a newline in the author list with LaTeX2HTML. The result is shown below.

LaTeX2HTML:

<img width="686" height="209" alt="image" src="https://github.com/user-attachments/assets/9dbfd425-f9a0-4634-a4e8-4edb6c68bb2d" />

TeX4ht:

<img width="504" height="197" alt="image" src="https://github.com/user-attachments/assets/25098317-2a05-4bee-ab3d-47bd740dd6b9" />

PDF:

<img width="422" height="179" alt="image" src="https://github.com/user-attachments/assets/ac223e58-6c56-4add-a136-3b2e40c3a2f5" />