### PR TITLE
docs(manual): fix duplicate labels and correct section hierarchy

### DIFF
--- a/doc/manual/functions.tex
+++ b/doc/manual/functions.tex
@@ -1302,7 +1302,7 @@ nothing is done.
 %--#[ tofloat_ :
 
 \section{tofloat\_}\index{tofloat\_}\index{function!tofloat\_}
-\label{funmatch}
+\label{funtofloat}
 \noindent Currently not active.
 
 %--#] tofloat_ : 
@@ -1317,7 +1317,7 @@ diagrams~\ref{diagrams}.
 %--#[ torat_ :
 
 \section{torat\_}\index{torat\_}\index{function!torat\_}
-\label{funmatch}
+\label{funtorat}
 \noindent Currently not active.
 
 %--#] torat_ : 

--- a/doc/manual/optim.tex
+++ b/doc/manual/optim.tex
@@ -123,7 +123,7 @@ expressions one by one when we use the \#optimize instruction, while in the
 regular printing of the output this is not needed because the expression 
 itself remains in its unoptimized version.
 
-\subsection{Optimization options of the Format statement}
+\section{Optimization options of the Format statement}
 
 The \verb|Format| statement has a number of options to control the
 code optimization. The easiest to use are the following:

--- a/doc/manual/statements.tex
+++ b/doc/manual/statements.tex
@@ -552,7 +552,7 @@ more details, see chapter \ref{gammaalgebra} on gamma\index{gamma algebra} algeb
 %--#] chisholm : 
 %--#[ chop :
 \section{chop}
-\label{substaevaluate}
+\label{substachop}
 
 \noindent \begin{tabular}{ll}
 Type & Executable statement\\
@@ -5331,7 +5331,7 @@ specified all arguments will be treated. \vspace{10mm}
 %--#] splitlastarg : 
 %--#[ strictrounding :
 \section{strictrounding}
-\label{substaevaluate}
+\label{substastrictrounding}
 
 \noindent \begin{tabular}{ll}
 Type & Executable statement\\


### PR DESCRIPTION
This PR fixes duplicated labels `substaevaluate` and `funmatch`. It also promotes `Optimization options of the Format statement` from a subsection to a section, because that part had no section heading, which resulted in a "hierarchy problem" (causing the section number to become `10.0.1`).

There is still something weird in the LaTeX source. There are several instances of `\setcounter{equation}{...}`:
```
doc/manual/statements.tex
532:\setcounter{equation}{2}
4691:\setcounter{equation}{3}
5369:\setcounter{equation}{4}
5376:\setcounter{equation}{5}
5971:\setcounter{equation}{6}
6021:\setcounter{equation}{7}
```
Do we need these counter manipulations?