### PR TITLE
fix: tform: potential crash due to race when MODMAX/MODMIN

### DIFF
--- a/sources/dollar.c
+++ b/sources/dollar.c
@@ -394,14 +394,11 @@ NoChangeOne:;
 	}
 /*
 	Now the real evaluation.
-	In the case of threads and MODSUM this requires an immediate lock.
-	Otherwise the lock could be placed later.
+	We need to lock here before we work out the RHS, in case the RHS itself
+	depends on the dollar variable.
 */
 #ifdef WITHPTHREADS
-	if ( dtype == MODSUM ) {
-/*		LOCK(d->pthreadslockwrite); */
-		LOCK(d->pthreadslockread);
-	}
+	LOCK(d->pthreadslockread);
 #endif
 	CleanDollarFactors(d);
 /*
@@ -445,12 +442,7 @@ NoChangeOne:;
 		}
 		numterms = 0; t = ss; while ( *t ) { numterms++; t += *t; }
 	}
-#ifdef WITHPTHREADS
-	if ( dtype != MODSUM ) {
-/*		LOCK(d->pthreadslockwrite); */
-		LOCK(d->pthreadslockread);
-	}
-#endif
+
 	if ( numterms == 0 ) {
 /*
 		the new value evaluates to zero


### PR DESCRIPTION
A worker could free a dollar variable's data, while another worker is trying to read it. Lock the dollar variable before working out its RHS in case the RHS depends on the dollar variable that is being assigned.

This closes #147 and #796 , though #796 contains more discussion for the future.