### PR TITLE
perf: copy optimization

### DIFF
--- a/sources/declare.h
+++ b/sources/declare.h
@@ -69,11 +69,18 @@
 
 /* (n) is necessary here, since the macro is sometimes passed dereferenced pointers for n */
 #define NCOPY(s,t,n) { while ( (n)-- > 0 ) { *s++ = *t++; } }
-/*#define NCOPY(s,t,n) { memcpy(s,t,n*sizeof(WORD)); s+=n; t+=n; n = -1; }*/
 #define NCOPYI(s,t,n) { while ( (n)-- > 0 ) { *s++ = *t++; } }
 #define NCOPYB(s,t,n) { while ( (n)-- > 0 ) { *s++ = *t++; } }
 #define NCOPYI32(s,t,n) { while ( (n)-- > 0 ) { *s++ = *t++; } }
 #define WCOPY(s,t,n) { int nn=n; WORD *ss=(WORD *)s, *tt=(WORD *)t; while ( (nn)-- > 0 ) { *ss++ = *tt++; } }
+
+/* Use memmove not memcpy: we can't guarantee that s, t do not overlap */
+/* Using memmove produces no measurable performance improvement or regression. */
+/*#define NCOPY(s,t,n) { memmove(s,t,(n)*sizeof(*s)); s+=n; t+=n; n=0; }
+#define NCOPYI(s,t,n) { NCOPY(s,t,n); }
+#define NCOPYB(s,t,n) { NCOPY(s,t,n); }
+#define NCOPYI32(s,t,n) { NCOPY(s,t,n); }
+#define WCOPY(s,t,n) { int nn=n; WORD *ss=(WORD *)s, *tt=(WORD *)t; NCOPY(ss,tt,nn); }*/
 
 #define NeedNumber(x,s,err) { int sgn = 1;                               \
 		while ( *s == ' ' || *s == '\t' || *s == '-' || *s == '+' ) {      \

--- a/sources/proces.c
+++ b/sources/proces.c
@@ -2220,11 +2220,10 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 					AR.DeferFlag = 0;
 					v = t + *t;
 					t += ARGHEAD;		/* First term */
-					w = 0;	/* to appease the compilers warning devices */
-					while ( from < t ) {
-						if ( from == u ) w = m;
-						*m++ = *from++;
-					}
+					LONG copy = t - from;
+					const LONG size = t - u;
+					NCOPY(m, from, copy);
+					w = m - size;
 					to = m;
 					NewSort(BHEAD0);
 					if ( *u == AR.PolyFun && AR.PolyFunType == 2 ) {
@@ -2314,11 +2313,10 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 						&& ( *u != AR.PolyFun ) ) { AN.ncmod = 0; }
 					AR.DeferFlag = 0;
 					v = t + 2;
-					w = 0;	/* to appease the compilers warning devices */
-					while ( from < t ) {
-						if ( from == u ) w = m;
-						*m++ = *from++;
-					}
+					LONG copy = t - from;
+					const LONG size = t - u;
+					NCOPY(m, from, copy);
+					w = m - size;
 					to = m;
 					switch ( d->type ) {
 						case DOLINDEX:
@@ -2481,11 +2479,10 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 					u points at the start of the function
 					t points at the start of the argument
 */
-					w = 0;
-					while ( from < t ) {
-						if ( from == u ) w = m;
-						*m++ = *from++;
-					}
+					LONG copy = t - from;
+					const LONG size = t - u;
+					NCOPY(m, from, copy);
+					w = m - size;
 					if ( ( numterms & MAXPOSITIVE ) == numterms ) {
 						*m++ = -SNUMBER; *m++ =  numterms & MAXPOSITIVE;
 						w[1] += 1;
@@ -2548,11 +2545,11 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 					if ( ( AN.ncmod != 0 )
 						&& ( ( AC.modmode & ALSOFUNARGS ) == 0 )
 						&& ( *u != AR.PolyFun ) ) { AN.ncmod = 0; }
-					m = termout; w = 0;
-					while ( from < t ) {
-						if ( from == u ) w = m;
-						*m++ = *from++;
-					}
+					m = termout;
+					LONG copy = t - from;
+					const LONG size = t - u;
+					NCOPY(m, from, copy);
+					w = m - size;
 					to = m;
 					switch ( d->type ) {
 						case DOLINDEX:

--- a/sources/threads.c
+++ b/sources/threads.c
@@ -3543,9 +3543,9 @@ int PutToMaster(PHEAD WORD *term)
 	fill = AT.SB.MasterFill[i];     /* Where we are filling */
 	top = AT.SB.MasterStop[i];      /* End of the block */
 	while ( j > 0 ) {
-		while ( j > 0 && fill < top ) {
-			*fill++ = *t++; j--;
-		}
+		LONG copy = MiN(top - fill, j);
+		j -= copy;
+		NCOPY(fill, t, copy);
 		if ( j > 0 ) {
 /*
 			We reached the end of the block.


### PR DESCRIPTION
Here is an optimisation experiment, replacing all NCOPY/WCOPY macros with memmove (we can't be sure that memory regions never overlap in use of the macro for memcpy). The replacement alone is a negligible performance improvement (tentatively 1%?) but it is hard to detect within the usual run-to-run variation.

The followup commits improve some existing copies within the code by using the macros instead, and moving some conditionals outside of the copies. I identified the expensive copies with a profiler running the Forcer benchmark.

On my system (Ryzen 7900X, Ubuntu 24.04, GCC 13.3.0, tform -w12,), the results for the usual benchmarks are as follows:
| Benchmark | Speedup w.r.t. v5.0.0 |
| --------- | ------- |
| chromatic | 1.05 ± 0.01 |
| color | 1.01 ± 0.01 |
| fmft | 1.03 ± 0.01 |
| forcer | 1.07 ± 0.00 |
| forcer-exp | 1.08 ± 0.01 |
| mass-fact | 1.00 ± 0.05 |
| mbox1l | 1.01 ± 0.02 |
| minceex | 1.07 ± 0.02 |
| mincer | 1.00 ± 0.05 |
| sort-disk | 0.98 ± 0.02 |
| sort-large | 0.99 ± 0.01 |
| sort-small | 1.01 ± 0.01 |
| trace | 1.02 ± 0.01 |
