### PR TITLE
fix: Typo in store.c / GetTable leading to e.g. a memory leak

### DIFF
--- a/sources/store.c
+++ b/sources/store.c
@@ -3207,7 +3207,7 @@ GetTb3:
 					WCOPY(buffer, AS.Olduflags, AS.NumOldNumFactors);
 					M_free(AS.Olduflags, "uflags pointers");
 				}
-				AS.Oldvflags = buffer;
+				AS.Olduflags = buffer;
 
 				AS.NumOldNumFactors = capacity;
 			}


### PR DESCRIPTION
Fixes #808

In `GetTable` (`sources/store.c`), a buffer reallocation for `AS.Olduflags` incorrectly assigned the new buffer to `AS.Oldvflags`, leaving `AS.Olduflags` pointing to freed memory and leaking the new allocation. The root cause was a copy-paste or typo error on the assignment line following the `M_free` call. Corrects the assignment to `AS.Olduflags = buffer` in `sources/store.c:3210`, ensuring the reallocated buffer is properly tracked. Verified by code inspection confirming the surrounding reallocation pattern for `AS.NumOldNumFactors` and `AS.Olduflags` is now self-consistent.