### PR TITLE
fix: tform: regression due to #797

### DIFF
--- a/check/fixes.frm
+++ b/check/fixes.frm
@@ -2476,6 +2476,48 @@ P;
 assert succeeded?
 assert result("F") =~ expr("9999")
 *--#] Issue268_2 :
+*--#[ Issue271 : 
+#-
+#define N "16"
+Symbol x,n;
+Local test = -{`N'*(`N'+1)/2} + <x^1>+...+<x^`N'>;
+.sort
+#$split = 0;
+Identify x^n?pos_ = n;
+$split = $split + term_;
+ModuleOption sum $split;
+.sort
+#message split = `$split'
+Print;
+.end
+assert succeeded?
+assert stdout =~ exact_pattern(<<EOF)
+~~~split = 0
+EOF
+assert result("test") =~ expr("0")
+*--#] Issue271 : 
+*--#[ Issue271b : 
+#-
+#define N "16"
+Symbol x,n;
+Local test = -{`N'*(`N'+1)/2} + <x^1>+...+<x^`N'>;
+.sort
+#$split = 0;
+$split = $split + term_;
+ModuleOption sum $split;
+.sort
+#message split = `$split'
+Print;
+.end
+# This symbolic sum doesn't work in TFORM, but does work in ParFORM:
+#pend_if threaded?
+assert succeeded?
+assert stdout =~ exact_pattern(<<EOF)
+~~~split = -136+x+x^2+x^3+x^4+x^5+x^6+x^7+x^8+x^9+x^10+x^11+x^12+x^13+x^14+x^15
++x^16
+EOF
+assert result("test") =~ expr("- 136 + x + x^2 + x^3 + x^4 + x^5 + x^6 + x^7 + x^8 + x^9 + x^10 + x^11 + x^12 + x^13 + x^14 + x^15 + x^16")
+*--#] Issue271b : 
 *--#[ Issue277 :
 * A question about addargs
 CFunction f,g,h;
@@ -4448,6 +4490,53 @@ assert warning?("Excess information in symmetric properties")
 assert warning?("Illegal information in number of arguments properties")
 assert warning?("Undefined $-variable")
 *--#] Issue766 : 
+*--#[ Issue796 : 
+* Regression: the fix for 796 deadlocks here:
+Symbol x;
+Local test = <x^1>+...+<x^128>;
+#$maxpow = 0;
+$maxpow = max_($maxpow,count_(x,1));
+ModuleOption maximum $maxpow;
+.sort
+#message maxpow: `$maxpow'
+.end
+assert succeeded?
+assert stdout =~ exact_pattern(<<'EOF')
+maxpow: 128
+EOF
+*--#] Issue796 : 
+*--#[ Issue796b : 
+* Regression: the fix for 796 deadlocks here:
+Symbol x;
+Local test = <x^1>+...+<x^128>;
+#$minpow = 129;
+$minpow = min_($minpow,count_(x,1));
+ModuleOption minimum $minpow;
+.sort
+#message minpow: `$minpow'
+.end
+assert succeeded?
+assert stdout =~ exact_pattern(<<'EOF')
+minpow: 1
+EOF
+*--#] Issue796b : 
+*--#[ Issue796c : 
+* This case has always deadlocked:
+Symbol x;
+Local test = <x^1>+...+<x^128>;
+#$sumpow = 129;
+$sumpow = max_($sumpow,count_(x,1));
+ModuleOption sum $sumpow;
+.sort
+#message sumpow: `$sumpow'
+.end
+# ParFORM does not pass this test
+#pend_if mpi?
+assert succeeded?
+assert stdout =~ exact_pattern(<<'EOF')
+sumpow: 129
+EOF
+*--#] Issue796c : 
 *--#[ PullReq535 :
 * This test requires more than the specified 50K workspace.
 #:maxtermsize 200

--- a/sources/checkpoint.c
+++ b/sources/checkpoint.c
@@ -2099,8 +2099,7 @@ int DoRecovery(int *moduletype)
 			R_COPY_B(d->where, size, void*);
 		}
 #ifdef WITHPTHREADS
-		d->pthreadslockread = dummylock;
-		d->pthreadslockwrite = dummylock;
+		d->pthreadslock = dummylock;
 #endif
 		if ( d->nfactors > 1 ) {
 			R_COPY_B(d->factors,sizeof(FACDOLLAR)*d->nfactors,FACDOLLAR*);

--- a/sources/checkpoint.c
+++ b/sources/checkpoint.c
@@ -2099,7 +2099,7 @@ int DoRecovery(int *moduletype)
 			R_COPY_B(d->where, size, void*);
 		}
 #ifdef WITHPTHREADS
-		d->pthreadslock = dummylock;
+		INIRECLOCK(d->pthreadslock);
 #endif
 		if ( d->nfactors > 1 ) {
 			R_COPY_B(d->factors,sizeof(FACDOLLAR)*d->nfactors,FACDOLLAR*);

--- a/sources/declare.h
+++ b/sources/declare.h
@@ -462,6 +462,12 @@ static inline LONG ULongToLong(ULONG x)
 #define INILOCK(x)    pthread_mutex_t x = PTHREAD_MUTEX_INITIALIZER;
 #define EXTERNRWLOCK(x) extern pthread_rwlock_t x;
 #define INIRWLOCK(x)    pthread_rwlock_t x = PTHREAD_RWLOCK_INITIALIZER;
+#define INIRECLOCK(x) do { pthread_mutexattr_t attrib; \
+	pthread_mutexattr_init(&attrib); \
+	pthread_mutexattr_settype(&attrib, PTHREAD_MUTEX_RECURSIVE); \
+	pthread_mutex_init(&(x), &attrib); \
+	pthread_mutexattr_destroy(&attrib); \
+	} while(0)
 #ifdef DEBUGGINGLOCKS
 #include <asm/errno.h>
 #define LOCK(x)       while ( pthread_mutex_trylock(&(x)) == EBUSY ) {}

--- a/sources/dollar.c
+++ b/sources/dollar.c
@@ -252,8 +252,7 @@ int AssignDollar(PHEAD WORD *term, WORD level)
 */
 #ifdef WITHPTHREADS
 		if ( dtype > 0 ) {
-/*			LOCK(d->pthreadslockwrite); */
-			LOCK(d->pthreadslockread);
+			LOCK(d->pthreadslock);
 NewValIsZero:;
 			switch ( d->type ) {
 				case DOLZERO: goto NoChangeZero;
@@ -278,8 +277,7 @@ NewValIsZero:;
 			cbuf[AM.dbufnum].NumTerms[numdollar] = 0;
 NoChangeZero:;
 			CleanDollarFactors(d);
-/*			UNLOCK(d->pthreadslockwrite); */
-			UNLOCK(d->pthreadslockread);
+			UNLOCK(d->pthreadslock);
 			AN.ncmod = oldncmod;
 			return(0);
 		}
@@ -301,8 +299,7 @@ NoChangeZero:;
 */
 #ifdef WITHPTHREADS
 		if ( dtype > 0 ) {
-/*			LOCK(d->pthreadslockwrite); */
-			LOCK(d->pthreadslockread);
+			LOCK(d->pthreadslock);
 			if ( d->size < MINALLOC ) {
 				WORD oldsize, *oldwhere, i;
 				oldsize = d->size; oldwhere = d->where;
@@ -365,8 +362,7 @@ HandleDolZero:;
 			cbuf[AM.dbufnum].NumTerms[numdollar] = 1;
 NoChangeOne:;
 			CleanDollarFactors(d);
-/*			UNLOCK(d->pthreadslockwrite); */
-			UNLOCK(d->pthreadslockread);
+			UNLOCK(d->pthreadslock);
 			AN.ncmod = oldncmod;
 			return(0);
 		}
@@ -398,7 +394,7 @@ NoChangeOne:;
 	depends on the dollar variable.
 */
 #ifdef WITHPTHREADS
-	LOCK(d->pthreadslockread);
+	LOCK(d->pthreadslock);
 #endif
 	CleanDollarFactors(d);
 /*
@@ -566,8 +562,7 @@ HandleDolZero1:;
 	}
 #ifdef WITHPTHREADS
 NoChange:;
-/*	UNLOCK(d->pthreadslockwrite); */
-	UNLOCK(d->pthreadslockread);
+	UNLOCK(d->pthreadslock);
 #endif
 	AN.ncmod = oldncmod;
 	return(0);
@@ -1088,7 +1083,7 @@ WORD DolToTensor(PHEAD WORD numdollar)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
@@ -1122,7 +1117,7 @@ WORD DolToTensor(PHEAD WORD numdollar)
 		retval = 0;
 	}
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(retval);
 }
@@ -1149,7 +1144,7 @@ WORD DolToFunction(PHEAD WORD numdollar)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
@@ -1179,7 +1174,7 @@ WORD DolToFunction(PHEAD WORD numdollar)
 		retval = 0;
 	}
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(retval);
 }
@@ -1206,7 +1201,7 @@ WORD DolToVector(PHEAD WORD numdollar)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
@@ -1243,7 +1238,7 @@ WORD DolToVector(PHEAD WORD numdollar)
 		retval = 0;
 	}
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(retval);
 }
@@ -1329,7 +1324,7 @@ WORD DolToSymbol(PHEAD WORD numdollar)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
@@ -1356,7 +1351,7 @@ WORD DolToSymbol(PHEAD WORD numdollar)
 		retval = -1;
 	}
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(retval);
 }
@@ -1383,7 +1378,7 @@ WORD DolToIndex(PHEAD WORD numdollar)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
@@ -1432,7 +1427,7 @@ WORD DolToIndex(PHEAD WORD numdollar)
 		retval = 0;
 	}
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(retval);
 }
@@ -1571,8 +1566,7 @@ ShortArgument:
 	newd->size = size;
 	newd->numdummies = d->numdummies;
 #ifdef WITHPTHREADS
-	newd->pthreadslockread  = dummylock;
-	newd->pthreadslockwrite = dummylock;
+	newd->pthreadslock  = dummylock;
 #endif
 	size++;
 	NCOPY(t,w,size);
@@ -1763,8 +1757,7 @@ int InsideDollar(PHEAD WORD *ll, WORD level)
 					d = ModOptdollars[nummodopt].dstruct+AT.identity;
 				}
 				else {
-/*					LOCK(d->pthreadslockwrite); */
-					LOCK(d->pthreadslockread);
+					LOCK(d->pthreadslock);
 				}
 			}
 		}
@@ -1817,8 +1810,7 @@ int InsideDollar(PHEAD WORD *ll, WORD level)
 */
 #ifdef WITHPTHREADS
 		if ( dtype > 0 && dtype != MODLOCAL ) {
-/*			UNLOCK(d->pthreadslockwrite); */
-			UNLOCK(d->pthreadslockread);
+			UNLOCK(d->pthreadslock);
 		}
 #endif
 		if ( newd->factors ) M_free(newd->factors,"Dollar factors");
@@ -1874,7 +1866,7 @@ LONG TermsInDollar(WORD num)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
@@ -1895,7 +1887,7 @@ LONG TermsInDollar(WORD num)
 	else if ( d->type == DOLZERO ) n = 0;
 	else n = 1;
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(n);
 }
@@ -1923,7 +1915,7 @@ LONG SizeOfDollar(WORD num)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
@@ -1947,7 +1939,7 @@ LONG SizeOfDollar(WORD num)
 	else if ( d->type == DOLZERO ) n = 0;
 	else n = 1;
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(n);
 }
@@ -2974,14 +2966,14 @@ int DollarFactorize(PHEAD WORD numdollar)
 				d = ModOptdollars[nummodopt].dstruct+AT.identity;
 			}
 			else {
-				LOCK(d->pthreadslockread);
+				LOCK(d->pthreadslock);
 			}
 		}
 	}
 #endif
 	CleanDollarFactors(d);
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	if ( d->type != DOLTERMS ) {	/* only one term */
 		if ( d->type != DOLZERO ) d->nfactors = 1;
@@ -3231,13 +3223,13 @@ getout:
 		        Be careful: there should be more than one factor now.
 */
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { LOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { LOCK(d->pthreadslock); }
 #endif
 	if ( nfactors ==  1 && extrafactor == 0 ) {	/* we can use the buf1 contents */
 		if ( factorsincontent == 0 ) {
 			d->nfactors = 1;
 #ifdef WITHPTHREADS
-			if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+			if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 /*
 			We used here (before 3-sep-2015) the original and did not make
@@ -3289,7 +3281,7 @@ getout2:			AR.SortType = oldsorttype;
 					M_free(d->factors,"factors in dollar");
 					d->factors = 0;
 #ifdef WITHPTHREADS
-					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 					M_free(buf3,"DollarFactorize-4");
 					if ( buf2 != buf1 && buf2 ) M_free(buf2,"DollarFactorize-4");
@@ -3533,7 +3525,7 @@ nextj:;
  		#] Step 8: 
 */
 #ifdef WITHPTHREADS
-	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+	if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 	return(0);
 }

--- a/sources/dollar.c
+++ b/sources/dollar.c
@@ -35,8 +35,6 @@
 
 #include "form3.h"
 
-/* EXTERNLOCK(dummylock) */
-
 static UBYTE underscore[2] = {'_',0};
 
 /*
@@ -1566,7 +1564,7 @@ ShortArgument:
 	newd->size = size;
 	newd->numdummies = d->numdummies;
 #ifdef WITHPTHREADS
-	newd->pthreadslock  = dummylock;
+	INIRECLOCK(newd->pthreadslock);
 #endif
 	size++;
 	NCOPY(t,w,size);

--- a/sources/if.c
+++ b/sources/if.c
@@ -475,7 +475,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 								d = ModOptdollars[nummodopt].dstruct+AT.identity;
 							}
 							else {
-								LOCK(d->pthreadslockread);
+								LOCK(d->pthreadslock);
 							}
 						}
 					}
@@ -532,7 +532,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 						case DOLUNDEFINED:
 							if ( AC.UnsureDollarMode == 0 ) {
 #ifdef WITHPTHREADS
-								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 								MLOCK(ErrorMessageLock);
 								MesPrint("$%s is undefined",AC.dollarnames->namebuffer+d->name);
@@ -549,7 +549,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 							|| d->where[2] < 0 || d->where[2] >= AM.OffsetIndex ) {
 								if ( AC.UnsureDollarMode == 0 ) {
 #ifdef WITHPTHREADS
-									if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+									if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 									MLOCK(ErrorMessageLock);
 									MesPrint("$%s is of wrong type",AC.dollarnames->namebuffer+d->name);
@@ -570,7 +570,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 							}
 							else if ( AC.UnsureDollarMode == 0 ) {
 #ifdef WITHPTHREADS
-								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 								MLOCK(ErrorMessageLock);
 								MesPrint("$%s is of wrong type",AC.dollarnames->namebuffer+d->name);
@@ -586,7 +586,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 							) {
 								if ( AC.UnsureDollarMode == 0 ) {
 #ifdef WITHPTHREADS
-									if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+									if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 									MLOCK(ErrorMessageLock);
 									MesPrint("$%s is of wrong type",AC.dollarnames->namebuffer+d->name);
@@ -635,7 +635,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 							else {
 								if ( AC.UnsureDollarMode == 0 ) {
 #ifdef WITHPTHREADS
-									if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+									if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 									MLOCK(ErrorMessageLock);
 									MesPrint("$%s is of wrong type",AC.dollarnames->namebuffer+d->name);
@@ -661,7 +661,7 @@ int DoIfStatement(PHEAD WORD *ifcode, WORD *term)
 generic:;
 							if ( AC.UnsureDollarMode == 0 ) {
 #ifdef WITHPTHREADS
-								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 								MLOCK(ErrorMessageLock);
 								MesPrint("$%s is of wrong type",AC.dollarnames->namebuffer+d->name);
@@ -673,7 +673,7 @@ generic:;
 					  }
 					}
 #ifdef WITHPTHREADS
-					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 				}
 				break;

--- a/sources/message.c
+++ b/sources/message.c
@@ -425,7 +425,7 @@ int MesPrint(const char *fmt, ... )
 								d = ModOptdollars[nummodopt].dstruct+AT.identity;
 							}
 							else {
-								LOCK(d->pthreadslockread);
+								LOCK(d->pthreadslock);
 							}
 						}
 					}
@@ -480,7 +480,7 @@ printterms:				first = 1;
 							AddToLine((UBYTE *)Out);
 							if ( WriteInnerTerm(term,first) ) {
 #ifdef WITHPTHREADS
-								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 								Terminate(-1);
 							}
@@ -511,7 +511,7 @@ dosubterm:				if ( AC.LineLength > MAXLINELENGTH ) AC.LineLength = MAXLINELENGTH
 						AddToLine((UBYTE *)Out);
 						if ( WriteSubTerm(tt,1) ) {
 #ifdef WITHPTHREADS
-							if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 							Terminate(-1);
 						}
@@ -615,7 +615,7 @@ dollarzero:				*t++ = '0'; *t = 0;
 						}
 					}
 #ifdef WITHPTHREADS
-					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 					AN.listinprint += 2;
 					while ( AN.listinprint[0] == DOLLAREXPR2 ) AN.listinprint += 2;

--- a/sources/module.c
+++ b/sources/module.c
@@ -718,8 +718,7 @@ UBYTE * DoModDollar(UBYTE *s, int type)
 							dlocal->where[i] = dglobal->where[i];
 						dlocal->where[dlocal->size] = 0;
 					}
-					dlocal->pthreadslockread = dummylock;
-					dlocal->pthreadslockwrite = dummylock;
+					dlocal->pthreadslock = dummylock;
 					dlocal->nfactors = dglobal->nfactors;
 					if ( dglobal->nfactors > 1 ) {
 						int nsize;

--- a/sources/module.c
+++ b/sources/module.c
@@ -718,7 +718,7 @@ UBYTE * DoModDollar(UBYTE *s, int type)
 							dlocal->where[i] = dglobal->where[i];
 						dlocal->where[dlocal->size] = 0;
 					}
-					dlocal->pthreadslock = dummylock;
+					INIRECLOCK(dlocal->pthreadslock);
 					dlocal->nfactors = dglobal->nfactors;
 					if ( dglobal->nfactors > 1 ) {
 						int nsize;

--- a/sources/names.c
+++ b/sources/names.c
@@ -2612,7 +2612,7 @@ int AddDollar(UBYTE *name, WORD type, WORD *start, LONG size)
 	dol->zero = 0;
 	dol->numdummies = 0;
 #ifdef WITHPTHREADS
-	dol->pthreadslock = dummylock;
+	INIRECLOCK(dol->pthreadslock);
 #endif
 	dol->nfactors = 0;
 	dol->factors = 0;

--- a/sources/names.c
+++ b/sources/names.c
@@ -2612,8 +2612,7 @@ int AddDollar(UBYTE *name, WORD type, WORD *start, LONG size)
 	dol->zero = 0;
 	dol->numdummies = 0;
 #ifdef WITHPTHREADS
-	dol->pthreadslockread = dummylock;
-	dol->pthreadslockwrite = dummylock;
+	dol->pthreadslock = dummylock;
 #endif
 	dol->nfactors = 0;
 	dol->factors = 0;

--- a/sources/normal.c
+++ b/sources/normal.c
@@ -561,14 +561,14 @@ NextSymbol:;
 							d = ModOptdollars[nummodopt].dstruct+AT.identity;
 						}
 						else {
-							LOCK(d->pthreadslockread);
+							LOCK(d->pthreadslock);
 						}
 					}
 				}
 #endif
 				if ( d->type == DOLZERO ) {
 #ifdef WITHPTHREADS
-					if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 					if ( t[3] == 0 ) goto NormZZ;
 					if ( t[3] < 0 ) goto NormInf;
@@ -584,7 +584,7 @@ NextSymbol:;
 					}
 					if ( nnum == 0 || ( nnum == 1 && lnum[0] == 0 ) ) {
 #ifdef WITHPTHREADS
-						if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+						if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 						if ( t[3] < 0 ) goto NormInf;
 						else if ( t[3] == 0 ) goto NormZZ;
@@ -595,7 +595,7 @@ NextSymbol:;
 					if ( t[3] < 0 ) {
 						if ( Divvy(BHEAD (UWORD *)n_coef,&ncoef,(UWORD *)lnum,nnum) ) {
 #ifdef WITHPTHREADS
-							if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 							goto FromNorm;
 						}
@@ -603,7 +603,7 @@ NextSymbol:;
 					else if ( t[3] > 0 ) {
 						if ( Mully(BHEAD (UWORD *)n_coef,&ncoef,(UWORD *)lnum,nnum) ) {
 #ifdef WITHPTHREADS
-							if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 							goto FromNorm;
 						}
@@ -613,7 +613,7 @@ NextSymbol:;
 				else if ( d->type == DOLINDEX ) {
 					if ( d->index == 0 ) {
 #ifdef WITHPTHREADS
-						if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+						if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 						goto NormZero;
 					}
@@ -684,7 +684,7 @@ IllDollarExp:
 					t[4] = AM.dbufnum;
 					if ( t[3] == 0 ) {
 #ifdef WITHPTHREADS
-						if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+						if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 						break;
 					}
@@ -693,7 +693,7 @@ IllDollarExp:
 					while ( t < m ) {
 						if ( *t == DOLLAREXPRESSION ) {
 #ifdef WITHPTHREADS
-							if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 							d = Dollars + t[2];
 #ifdef WITHPTHREADS
@@ -707,7 +707,7 @@ IllDollarExp:
 										d = ModOptdollars[nummodopt].dstruct+AT.identity;
 									}
 									else {
-										LOCK(d->pthreadslockread);
+										LOCK(d->pthreadslock);
 									}
 								}
 							}
@@ -720,13 +720,13 @@ IllDollarExp:
 						t += t[1];
 					}
 #ifdef WITHPTHREADS
-					if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 					goto RegEnd;
 				}
 				else {
 #ifdef WITHPTHREADS
-					if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 					MLOCK(ErrorMessageLock);
 					MesPrint("!!!This $ variation has not been implemented yet!!!");
@@ -734,7 +734,7 @@ IllDollarExp:
 					goto NormMin;
 				}
 #ifdef WITHPTHREADS
-				if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+				if ( ptype > 0 && ptype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 				}
 				else {

--- a/sources/proces.c
+++ b/sources/proces.c
@@ -2302,7 +2302,7 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 								d = ModOptdollars[nummodopt].dstruct+AT.identity;
 							}
 							else {
-								LOCK(d->pthreadslockread);
+								LOCK(d->pthreadslock);
 							}
 						}
 					}
@@ -2447,12 +2447,12 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 							AC.dollarnames->namebuffer+d->name);
 							MUNLOCK(ErrorMessageLock);
 #ifdef WITHPTHREADS
-							if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 							Terminate(-1);
 					}
 #ifdef WITHPTHREADS
-					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 					r = term + *term;
 					t = v;
@@ -2536,7 +2536,7 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 								d = ModOptdollars[nummodopt].dstruct+AT.identity;
 							}
 							else {
-								LOCK(d->pthreadslockread);
+								LOCK(d->pthreadslock);
 							}
 						}
 					}
@@ -2566,7 +2566,7 @@ int InFunction(PHEAD WORD *term, WORD *termout)
 							else {
 wrongtype:;
 #ifdef WITHPTHREADS
-								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+								if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 								MLOCK(ErrorMessageLock);
 								MesPrint("$%s has wrong type for tensor substitution",
@@ -2632,7 +2632,7 @@ wrongtype:;
 							break;
 						case DOLUNDEFINED:
 #ifdef WITHPTHREADS
-							if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 							MLOCK(ErrorMessageLock);
 							MesPrint("$%s is undefined in tensor substitution",
@@ -2642,7 +2642,7 @@ wrongtype:;
 							return(-1);
 					}
 #ifdef WITHPTHREADS
-					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+					if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 					w[1] = w[1] - 2 + (m-to);
 					from += 2;
@@ -3456,7 +3456,7 @@ SkipCount:	level++;
 										d = ModOptdollars[nummodopt].dstruct+AT.identity;
 									}
 									else {
-										LOCK(d->pthreadslockread);
+										LOCK(d->pthreadslock);
 									}
 								}
 							}
@@ -3480,13 +3480,13 @@ SkipCount:	level++;
 								,AC.dollarnames->namebuffer+d->name);
 								MUNLOCK(ErrorMessageLock);
 #ifdef WITHPTHREADS
-							if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 								goto GenCall;
 							}
 							theindex = d->index;
 #ifdef WITHPTHREADS
-							if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+							if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 						}
 						cp[1] = SUBEXPSIZE+4;
@@ -3551,7 +3551,7 @@ SkipCount:	level++;
 											d = ModOptdollars[nummodopt].dstruct+AT.identity;
 										}
 										else {
-											LOCK(d->pthreadslockread);
+											LOCK(d->pthreadslock);
 										}
 									}
 								}
@@ -3574,13 +3574,13 @@ SkipCount:	level++;
 									,AC.dollarnames->namebuffer+d->name);
 									MUNLOCK(ErrorMessageLock);
 #ifdef WITHPTHREADS
-									if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+									if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 									goto GenCall;
 								}
 								theindex = d->index;
 #ifdef WITHPTHREADS
-								if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+								if ( ddtype > 0 && ddtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 							}
 							*cp++ = INDTOIND;
@@ -4197,7 +4197,7 @@ AutoGen:	i = *AT.TMout;
 							MUNLOCK(ErrorMessageLock);
 							goto GenCall;
 						}
-						LOCK(d->pthreadslockread);
+						LOCK(d->pthreadslock);
 					}
 				}
 			}
@@ -4232,7 +4232,7 @@ AutoGen:	i = *AT.TMout;
 				}
 */
 #ifdef WITHPTHREADS
-				if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslockread); }
+				if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslock); }
 				if ( ( AS.Balancing && CC->numrhs == 0 ) && StartBuf[posisub] ) {
 					if ( ( id = ConditionalGetAvailableThread() ) >= 0 ) {
 						if ( BalanceRunThread(BHEAD id,termout,level) < 0 ) goto GenCall;
@@ -4259,7 +4259,7 @@ AutoGen:	i = *AT.TMout;
 				Ce->Pointer = Ce->rhs[Ce->numrhs--];
 			}
 #ifdef WITHPTHREADS
-			if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslockread); dtype = 0; }
+			if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslock); dtype = 0; }
 #endif
 			if ( iscopy ) {
 				if ( d->nfactors > 1 ) {
@@ -4317,7 +4317,7 @@ AutoGen:	i = *AT.TMout;
 					*AN.RepPoint = 1;
 					AR.expchanged = 1;
 #ifdef WITHPTHREADS
-					if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslockread); }
+					if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslock); }
 					if ( ( AS.Balancing && CC->numrhs == 0 ) && ( i > 0 )
 					&& ( id = ConditionalGetAvailableThread() ) >= 0 ) {
 						if ( BalanceRunThread(BHEAD id,termout,level) < 0 ) goto GenCall;
@@ -4334,7 +4334,7 @@ AutoGen:	i = *AT.TMout;
 				}
 			} while ( i > 0 );
 #ifdef WITHPTHREADS
-			if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslockread); dtype = 0; }
+			if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslock); dtype = 0; }
 #endif
 			if ( iscopy ) {
 				if ( d->nfactors > 1 ) {
@@ -4381,7 +4381,7 @@ AutoGen:	i = *AT.TMout;
 					*AN.RepPoint = 1;
 					AR.expchanged = 1;
 #ifdef WITHPTHREADS
-					if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslockread); }
+					if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslock); }
 					if ( ( AS.Balancing && CC->numrhs == 0 ) && ( i > 0 ) && ( id = ConditionalGetAvailableThread() ) >= 0 ) {
 						if ( BalanceRunThread(BHEAD id,termout,level) < 0 ) goto GenCall;
 					}
@@ -4397,7 +4397,7 @@ AutoGen:	i = *AT.TMout;
 				}
 			}
 #ifdef WITHPTHREADS
-			if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslockread); dtype = 0; }
+			if ( dtype > 0 && dtype != MODLOCAL && dtype != MODSUM ) { UNLOCK(d->pthreadslock); dtype = 0; }
 #endif
 			if ( iscopy ) {
 				if ( d->nfactors > 1 ) {

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -542,8 +542,7 @@ typedef struct DoLlArS {
 	WORD	*where;				/* A pointer(!) to the object */
 	FACDOLLAR *factors;			/* an array of factors. nfactors elements */
 #ifdef WITHPTHREADS
-	pthread_mutex_t	pthreadslockread;
-	pthread_mutex_t	pthreadslockwrite;
+	pthread_mutex_t	pthreadslock;
 #endif
 	LONG	size;				/* The number of words */
 	LONG	name;

--- a/sources/transform.c
+++ b/sources/transform.c
@@ -2210,7 +2210,7 @@ int RunPermute(PHEAD WORD *fun, WORD *args, WORD *info)
 								d = ModOptdollars[nummodopt].dstruct+AT.identity;
 							}
 							else {
-								LOCK(d->pthreadslockread);
+								LOCK(d->pthreadslock);
 							}
 						}
 					}
@@ -2262,7 +2262,7 @@ IllType:
 								d = ModOptdollars[nummodopt].dstruct+AT.identity;
 							}
 							else {
-								LOCK(d->pthreadslockread);
+								LOCK(d->pthreadslock);
 							}
 						}
 					}

--- a/sources/wildcard.c
+++ b/sources/wildcard.c
@@ -1405,7 +1405,7 @@ int ResolveSet(PHEAD WORD *from, WORD *to, WORD *subs)
 						d = ModOptdollars[nummodopt].dstruct+AT.identity;
 					}
 					else {
-						LOCK(d->pthreadslockread);
+						LOCK(d->pthreadslock);
 					}
 				}
 			}
@@ -1440,7 +1440,7 @@ int ResolveSet(PHEAD WORD *from, WORD *to, WORD *subs)
 				}
 			}
 #ifdef WITHPTHREADS
-			if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+			if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 			MLOCK(ErrorMessageLock);
 			MesPrint("Unusable type of variable $%s in set substitution",
@@ -1450,7 +1450,7 @@ int ResolveSet(PHEAD WORD *from, WORD *to, WORD *subs)
 		}
 GotOne:;
 #ifdef WITHPTHREADS
-		if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslockread); }
+		if ( dtype > 0 && dtype != MODLOCAL ) { UNLOCK(d->pthreadslock); }
 #endif
 		ii = m[*w];
 		if ( ii >= 2*MAXPOWER ) i3 = ii - 2*MAXPOWER;


### PR DESCRIPTION
The fix of https://github.com/form-dev/form/pull/797 causes deadlocks when assigned MODMAX or MODMIN
dollars appear on their RHS, inside a function argument. In that
case, another lock on the dollar is attempted.

For example: `$dol = max_($dol,something);`

Use PTHREAD_MUTEX_RECURSIVE for dollar variables, such that a
thread may re-lock a dollar during assignment operations.

The MODSUM case has always deadlocked for such constructions.

-----

This also removes `pthreadslockwrite`, which is unused, and renames `pthreadslockread` as `pthreadslock`.

-----

This is about a 1% performance regression for fmft, mincer, minceex benchmarks (which should be largely recovered by #807).

----

I added test cases for the example of #271 in both tform and parform variants, which do not behave in the same way.