### PR TITLE
[ci] Update GitHub Actions to latest major release

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -276,7 +276,7 @@ runs:
 
     - name: Install dependencies (Ubuntu)
       if: runner.os == 'Linux' && steps.setup.outputs.container == 'false'
-      uses: awalsh128/cache-apt-pkgs-action@a605dbde2ac49a823c9c87ad58491b51848bf355  # for empty_packages_behavior
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.0  # for empty_packages_behavior
       with:
         # We assume libgmp-dev and zlib1g-dev are always installed.
         packages: >-
@@ -450,7 +450,7 @@ runs:
     - name: Cache FLINT
       id: cache-flint
       if: steps.setup.outputs.build_flint == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: lib/flint
         # Here, we set a conservative cache key so that the cache is not reused
@@ -509,7 +509,7 @@ runs:
     - name: Cache FORM library
       id: cache-formlib
       if: steps.setup.outputs.formlib == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: formlib
         key: ${{ steps.setup.outputs.formlib_key }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # ensures a reachable tag
 
@@ -36,7 +36,7 @@ jobs:
           tar -tf "$distname.tar.gz"
 
       - name: Upload tarball as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: src
           path: '*.tar.gz'
@@ -75,13 +75,13 @@ jobs:
           - {os: windows-2022, shell: msys2, bin: tform}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
       - name: Download tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: src
 
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload binary as artifact
         if: steps.check-portability.outcome == 'success' && steps.check-portability.conclusion == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.bin }}-${{ matrix.os }}
           path: |
@@ -146,13 +146,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
       - name: Download tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: src
 
@@ -174,7 +174,7 @@ jobs:
           file "$distname.pdf"
 
       - name: Upload document as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: doc-pdf
           path: '*.pdf'
@@ -188,13 +188,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
       - name: Download tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: src
 
@@ -236,7 +236,7 @@ jobs:
           tar -tf "$distname.tar.gz"
 
       - name: Upload file as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: doc-html
           path: '*.tar.gz'
@@ -255,7 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -316,7 +316,7 @@ jobs:
       # Upload the distributions as an artifact, regardless of whether
       # the commit has a versioning tag. This makes checking and debugging easy.
       - name: Upload distributions as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: |
@@ -333,7 +333,7 @@ jobs:
       # a versioning tag.
       - name: Publish distributions
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           - {bin: tform,   test: extra,   timeout: 60, nthreads: 2, flint: no}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # ensures a reachable tag
 
@@ -61,7 +61,7 @@ jobs:
           - {bin: parform, test: default, timeout: 15}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # ensures a reachable tag
 
@@ -120,7 +120,7 @@ jobs:
           - {bin: tvorm, test: extra,   nthreads: 2, group: 1/1}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # ensures a reachable tag
 
@@ -163,7 +163,7 @@ jobs:
           - {bin: tvorm, test: extra,   timeout: 60, nthreads: 2, flint: no}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # ensures a reachable tag
 


### PR DESCRIPTION
Fix deprecation warnings that Node20.js will stop working in June.

There is one case where `actions/checkout@v1` is used. This will still break in June. I am not aware of an obvious replacement.