### PR TITLE
perf: properly check for float mode in PutOut

### DIFF
--- a/sources/sort.c
+++ b/sources/sort.c
@@ -1604,7 +1604,7 @@ WORD PutOut(PHEAD WORD *term, POSITION *position, FILEHANDLE *fi, WORD ncomp)
 				}
 			}
 #ifdef WITHFLOAT
-			else if ( AC.DefaultPrecision ) {
+			else if ( AT.aux_ != 0 ) {
 				WORD *floatstop, *sa;
 				sa = p + i;
 				sa -= ABS(sa[-1]);


### PR DESCRIPTION
AC.DefaultPrecision is non-zero, even if we have not enabled floating point coefficients. Check for an allocated aux_ instead, to avoid searching terms for the floatstop unnecessarily.

I don't measure any performance change due to this, but in principle the current behaviour is not correct.