### PR TITLE
sources/float.c: avoid Terminate when float system not initialized

### DIFF
--- a/sources/float.c
+++ b/sources/float.c
@@ -378,7 +378,7 @@ int UnpackFloat(mpf_t outfloat,WORD *fun)
 		MesPrint("Illegal attempt at using a float_ function without proper startup.");
 		MesPrint("Please use %#StartFloat <options> first.");
 		MUNLOCK(ErrorMessageLock);
-		Terminate(-1);
+		return 0;
 	}
 /*
 	Check first the number and types of the arguments


### PR DESCRIPTION
## Summary
- Replace `Terminate(-1)` with `return 0` in `UnpackFloat()`
- When `#EndFloat` clears the float system and a subsequent operation tries to use a remaining `float_` function, `UnpackFloat()` now returns 0 instead of calling `Terminate()` which would immediately exit the program
- Callers that check the return value (e.g. `EvaluateFun` in `evaluate.c`) can now handle the error gracefully

## Changes
| File | Change |
|------|--------|
| sources/float.c | Changed `Terminate(-1)` → `return 0` in `UnpackFloat()` |

## Root Cause
When `#EndFloat` is executed, `ClearfFloat()` deallocates `AT.auxr_`. However, existing `float_` functions (e.g. `Local F = 3.0;`) still reference this deallocated memory. Subsequent operations (like `Multiply` or the `sort` statement) call `UnpackFloat()` to unpack these functions, which then tried to use the freed memory. The `Terminate(-1)` was intended as a safety check but was too aggressive — it exits the entire program instead of reporting the error to the caller.

## Test Plan
- Test with the two programs from the issue:
```form
#StartFloat 10d
Local F = 3.0;
Local G = 5.0;
Print +s;
.sort
#EndFloat
Local FG = F*G;
Print;
.end
```
- And the second variant with `Multiply`:
```form
#StartFloat 10d
Local F = 3.0;
.sort
#EndFloat
Multiply 5;
Print;
.end
```
- Both should complete without crashing

Fixes form-dev/form#836